### PR TITLE
Radio: add radio buttons, refactor

### DIFF
--- a/components/Radio/index.js
+++ b/components/Radio/index.js
@@ -1,3 +1,0 @@
-import Radio from './Radio.jsx';
-
-export default Radio;

--- a/components/RadioGroup/Radio.jsx
+++ b/components/RadioGroup/Radio.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const RadioIcon = () => (
-  <span className='radio--icon'>
-    <i className='circle-top'><span /></i>
-    <i className='circle-bottom'><span /></i>
-  </span>
-);
+import RadioIcon from './RadioIcon.jsx';
 
 const Radio = ({ checked, index, label, onChange }) => (
   <li>

--- a/components/RadioGroup/Radio.jsx
+++ b/components/RadioGroup/Radio.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RadioIcon from './RadioIcon.jsx';
 
-const Radio = ({ checked, index, label, onChange }) => (
+const Radio = ({ checked, index, label, onCheck }) => (
   <li>
     <input
       type='radio'
       checked={checked}
-      onChange={() => onChange(index)}
+      onChange={event => onCheck(event, index)}
     />
-    <label onClick={() => onChange(index)}>
+    <label onClick={event => onCheck(event, index)}>
       <RadioIcon />
       <span className='radio--label text-left'>{label}</span>
     </label>
@@ -20,7 +20,7 @@ Radio.propTypes = {
   checked: PropTypes.bool.isRequired,
   index: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
+  onCheck: PropTypes.func.isRequired,
 };
 
 export default Radio;

--- a/components/RadioGroup/RadioButton.jsx
+++ b/components/RadioGroup/RadioButton.jsx
@@ -2,13 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import RadioIcon from './RadioIcon.jsx';
-
-const If = ({ condition, children }) => (condition ? <div>{children}</div> : <div />);
-
-If.propTypes = {
-  condition: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired,
-};
+import If from '../util/If.jsx';
 
 function getDescriptionClassName(checked) {
   return classNames({
@@ -39,14 +33,14 @@ function getStyle(description) {
   return { marginTop: description ? '0px' : '8px' };
 }
 
-const RadioButton = ({ checked, description, index, label, onChange }) => (
+const RadioButton = ({ checked, description, index, label, onCheck }) => (
   <li>
     <input
       type='radio'
       checked={checked}
-      onChange={() => onChange(index)}
+      onChange={event => onCheck(event, index)}
     />
-    <label className={getClassName(checked)} onClick={() => onChange(index)}>
+    <label className={getClassName(checked)} onClick={event => onCheck(event, index)}>
       <RadioIcon />
       <span className='radio--label text-left padding-left-small' style={getStyle(description)}>
         <strong className={getTitleClassName(checked)}>{label}</strong>
@@ -63,7 +57,7 @@ RadioButton.propTypes = {
   index: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
   description: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
+  onCheck: PropTypes.func.isRequired,
 };
 
 RadioButton.defaultProps = {

--- a/components/RadioGroup/RadioButton.jsx
+++ b/components/RadioGroup/RadioButton.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import RadioIcon from './RadioIcon.jsx';
+
+const If = ({ condition, children }) => (condition ? <div>{children}</div> : <div />);
+
+If.propTypes = {
+  condition: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+function getDescriptionClassName(checked) {
+  return classNames({
+    'text--white': checked,
+    'text-4': true,
+  });
+}
+
+function getClassName(checked) {
+  return classNames({
+    'btn-teal': checked,
+    'btn-gray': !checked,
+    'btn--fill': true,
+    'btn-radio': true,
+    'margin-bottom-medium': true,
+  });
+}
+
+function getTitleClassName(checked) {
+  return classNames({
+    'text--white': checked,
+    'text--navy': !checked,
+    'text-2': true,
+  });
+}
+
+function getStyle(description) {
+  return { marginTop: description ? '0px' : '8px' };
+}
+
+const RadioButton = ({ checked, description, index, label, onChange }) => (
+  <li>
+    <input
+      type='radio'
+      checked={checked}
+      onChange={() => onChange(index)}
+    />
+    <label className={getClassName(checked)} onClick={() => onChange(index)}>
+      <RadioIcon />
+      <span className='radio--label text-left padding-left-small' style={getStyle(description)}>
+        <strong className={getTitleClassName(checked)}>{label}</strong>
+        <If condition={Boolean(description)}>
+          <p className={getDescriptionClassName(checked)}>{description}</p>
+        </If>
+      </span>
+    </label>
+  </li>
+);
+
+RadioButton.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  index: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
+
+RadioButton.defaultProps = {
+  description: '',
+};
+
+export default RadioButton;

--- a/components/RadioGroup/RadioButton.jsx
+++ b/components/RadioGroup/RadioButton.jsx
@@ -54,9 +54,9 @@ const RadioButton = ({ checked, description, index, label, onCheck }) => (
 
 RadioButton.propTypes = {
   checked: PropTypes.bool.isRequired,
+  description: PropTypes.string,
   index: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
-  description: PropTypes.string,
   onCheck: PropTypes.func.isRequired,
 };
 

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -15,8 +15,8 @@ function getClassName({ buttons, color, stacked }) {
 
 function getRadioComponent({ buttons, onCheck, selectedIndex }) {
   return buttons ?
-    (item, i) => <RadioButton onCheck={onCheck} index={i} key={i} checked={selectedIndex === i} {...item} /> :
-    (item, i) => <Radio onCheck={onCheck} index={i} key={i} checked={selectedIndex === i} {...item} />;
+    (item, i) => <RadioButton onCheck={onCheck} index={i} key={item.uniqueId} checked={selectedIndex === i} {...item} /> :
+    (item, i) => <Radio onCheck={onCheck} index={i} key={item.uniqueId} checked={selectedIndex === i} {...item} />;
 }
 
 const RadioGroup = ({ buttons, color, items, onCheck, selectedIndex, stacked }) => (
@@ -27,7 +27,10 @@ const RadioGroup = ({ buttons, color, items, onCheck, selectedIndex, stacked }) 
   </div>
 );
 
-const radioItemPropType = PropTypes.shape({ label: PropTypes.string.isRequired });
+const radioItemPropType = PropTypes.shape({
+  label: PropTypes.string.isRequired,
+  uniqueId: PropTypes.string.isRequired,
+});
 
 RadioGroup.propTypes = {
   buttons: PropTypes.bool,

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -13,16 +13,16 @@ function getClassName({ buttons, color, stacked }) {
   });
 }
 
-function getRadioComponent({ buttons, onChange, selectedIndex }) {
+function getRadioComponent({ buttons, onCheck, selectedIndex }) {
   return buttons ?
-    (item, i) => <RadioButton onChange={onChange} index={i} key={i} checked={selectedIndex === i} {...item} /> :
-    (item, i) => <Radio onChange={onChange} index={i} key={i} checked={selectedIndex === i} {...item} />;
+    (item, i) => <RadioButton onCheck={onCheck} index={i} key={i} checked={selectedIndex === i} {...item} /> :
+    (item, i) => <Radio onCheck={onCheck} index={i} key={i} checked={selectedIndex === i} {...item} />;
 }
 
-const RadioGroup = ({ buttons, color, items, onChange, selectedIndex, stacked }) => (
+const RadioGroup = ({ buttons, color, items, onCheck, selectedIndex, stacked }) => (
   <div className='form'>
     <ul className={getClassName({ buttons, color, stacked })}>
-      { items.map(getRadioComponent({ buttons, onChange, selectedIndex })) }
+      { items.map(getRadioComponent({ buttons, onCheck, selectedIndex })) }
     </ul>
   </div>
 );
@@ -33,7 +33,7 @@ RadioGroup.propTypes = {
   buttons: PropTypes.bool,
   color: PropTypes.oneOf([ 'teal', 'gray' ]),
   items: PropTypes.arrayOf(radioItemPropType).isRequired,
-  onChange: PropTypes.func,
+  onCheck: PropTypes.func,
   selectedIndex: PropTypes.number,
   stacked: PropTypes.bool,
 };
@@ -41,7 +41,7 @@ RadioGroup.propTypes = {
 RadioGroup.defaultProps = {
   buttons: false,
   color: 'teal',
-  onChange: () => {},
+  onCheck: () => {},
   selectedIndex: -1,
   stacked: false,
 };

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -1,20 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Radio from '../Radio';
+import Radio from './Radio.jsx';
+import RadioButton from './RadioButton.jsx';
 
-function getClassName({ color, stacked }) {
+function getClassName({ buttons, color, stacked }) {
   return classNames({
     'radio-teal': color === 'teal',
     'radio-gray': color === 'gray',
+    'radio--buttons': buttons,
     'radio--stacked': stacked,
   });
 }
 
-const RadioGroup = ({ color, items, onChange, selectedIndex, stacked }) => (
+function getRadioComponent({ buttons, onChange, selectedIndex }) {
+  return buttons ?
+    (item, i) => <RadioButton onChange={onChange} index={i} key={i} checked={selectedIndex === i} {...item} /> :
+    (item, i) => <Radio onChange={onChange} index={i} key={i} checked={selectedIndex === i} {...item} />;
+}
+
+const RadioGroup = ({ buttons, color, items, onChange, selectedIndex, stacked }) => (
   <div className='form'>
-    <ul className={getClassName({ color, stacked })}>
-      { items.map((item, i) => <Radio onChange={onChange} index={i} key={i} checked={selectedIndex === i} {...item} />) }
+    <ul className={getClassName({ buttons, color, stacked })}>
+      { items.map(getRadioComponent({ buttons, onChange, selectedIndex })) }
     </ul>
   </div>
 );
@@ -22,6 +30,7 @@ const RadioGroup = ({ color, items, onChange, selectedIndex, stacked }) => (
 const radioItemPropType = PropTypes.shape({ label: PropTypes.string.isRequired });
 
 RadioGroup.propTypes = {
+  buttons: PropTypes.bool,
   color: PropTypes.oneOf([ 'teal', 'gray' ]),
   items: PropTypes.arrayOf(radioItemPropType).isRequired,
   onChange: PropTypes.func,
@@ -30,6 +39,7 @@ RadioGroup.propTypes = {
 };
 
 RadioGroup.defaultProps = {
+  buttons: false,
   color: 'teal',
   onChange: () => {},
   selectedIndex: -1,

--- a/components/RadioGroup/RadioIcon.jsx
+++ b/components/RadioGroup/RadioIcon.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const RadioIcon = () => (
+  <span className='radio--icon'>
+    <i className='circle-top'><span /></i>
+    <i className='circle-bottom'><span /></i>
+  </span>
+);
+
+export default RadioIcon;

--- a/components/util/If.jsx
+++ b/components/util/If.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const If = ({ condition, children }) => (condition ? <div>{children}</div> : <div />);
+
+If.propTypes = {
+  condition: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default If;

--- a/demo/src/demo-radio.jsx
+++ b/demo/src/demo-radio.jsx
@@ -9,7 +9,7 @@ class StatefulRadio extends Component {
     this.setIndex = this.setIndex.bind(this);
   }
 
-  setIndex(selectedIndex) {
+  setIndex(event, selectedIndex) {
     this.setState({ selectedIndex });
   }
 
@@ -17,7 +17,7 @@ class StatefulRadio extends Component {
     return (
       <RadioGroup
         selectedIndex={this.state.selectedIndex}
-        onChange={this.setIndex}
+        onCheck={this.setIndex}
         {...this.props}
       />
     );

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -71,17 +71,17 @@ const AllComponents = () => (
     </Section>
     <Section title='Radios'>
       <Subtitle>Default</Subtitle>
-      <RadioDemo items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
+      <RadioDemo items={[{ label: 'Option 1', uniqueId: 'opt1' }, { label: 'Option 2', uniqueId: 'opt2' }]} />
       <Subtitle>Default gray</Subtitle>
-      <RadioDemo color='gray' items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
+      <RadioDemo color='gray' items={[{ label: 'Option 1', uniqueId: 'opt1' }, { label: 'Option 2', uniqueId: 'opt2' }]} />
       <Subtitle>Stacked</Subtitle>
-      <RadioDemo stacked items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
+      <RadioDemo stacked items={[{ label: 'Option 1', uniqueId: 'opt1' }, { label: 'Option 2', uniqueId: 'opt2' }]} />
       <Subtitle>Stacked gray</Subtitle>
-      <RadioDemo stacked color='gray' items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
+      <RadioDemo stacked color='gray' items={[{ label: 'Option 1', uniqueId: 'opt1' }, { label: 'Option 2', uniqueId: 'opt2' }]} />
       <Subtitle>Radio buttons</Subtitle>
-      <RadioDemo buttons items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
+      <RadioDemo buttons items={[{ label: 'Option 1', uniqueId: 'opt1' }, { label: 'Option 2', uniqueId: 'opt2' }]} />
       <Subtitle>Radio buttons with descriptions</Subtitle>
-      <RadioDemo buttons items={[{ label: 'Option 1', description: 'Description 1 goes here' }, { label: 'Option 2', description: 'Description 2 goes here' }]} />
+      <RadioDemo buttons items={[{ label: 'Option 1', description: 'Description 1 goes here', uniqueId: 'opt1' }, { label: 'Option 2', description: 'Description 2 goes here', uniqueId: 'opt2' }]} />
     </Section>
     <Section title='Text'>
       <Subtitle>Headings</Subtitle>

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -78,6 +78,10 @@ const AllComponents = () => (
       <RadioDemo stacked items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
       <Subtitle>Stacked gray</Subtitle>
       <RadioDemo stacked color='gray' items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
+      <Subtitle>Radio buttons</Subtitle>
+      <RadioDemo buttons items={[{ label: 'Option 1' }, { label: 'Option 2' }]} />
+      <Subtitle>Radio buttons with descriptions</Subtitle>
+      <RadioDemo buttons items={[{ label: 'Option 1', description: 'Description 1 goes here' }, { label: 'Option 2', description: 'Description 2 goes here' }]} />
     </Section>
     <Section title='Text'>
       <Subtitle>Headings</Subtitle>


### PR DESCRIPTION
This PR adds the `buttons` option to the `<RadioGroup>` component. It also cleans up the code by putting all radio-related components within the `components/RadioGroup` folder.