### PR TITLE
Added ability to test components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/components/Button/Button.test.jsx
+++ b/components/Button/Button.test.jsx
@@ -1,0 +1,29 @@
+import jsdom from 'mocha-jsdom';
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import Button from './button';
+
+describe('Button', () => {
+  jsdom();
+
+  it('Renders', () => {
+    const wrapper = mount(<Button>foo</Button>);
+    expect(wrapper.props().children).to.equal('foo');
+  });
+
+  it('Accepts click events', () => {
+    let callCount = 0;
+    const handleClick = () => callCount++;
+    const wrapper = mount(<Button onClick={handleClick}>foo</Button>);
+    expect(callCount).to.equal(0);
+    wrapper.find('button').simulate('click');
+    expect(callCount).to.equal(1);
+  });
+
+  it('Accepts arbitrary HTML attributes', () => {
+    const wrapper = mount(<Button height={20} id='123'>foo</Button>);
+    expect(wrapper.props().height).to.equal(20);
+    expect(wrapper.props().id).to.equal('123');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "rollup -c build/rollup.config.js",
     "dev": "rollup -c build/rollup.config.js --watch",
     "serve": "browser-sync start --server --serveStatic \"demo/public\" --files \"demo/public/js/bundle.js\" --no-open",
-    "start": "npm-run-all --parallel dev serve"
+    "start": "npm-run-all --parallel dev serve",
+    "test": "mocha components/**/*.test.jsx --compilers js:babel-register"
   },
   "repository": {
     "type": "git",
@@ -29,10 +30,17 @@
   "devDependencies": {
     "@vhx/eslint-config-vhx": "0.0.1",
     "autoprefixer": "^7.1.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-register": "^6.24.1",
     "browser-sync": "^2.18.12",
+    "chai": "^4.0.2",
+    "mocha": "^3.4.2",
+    "mocha-jsdom": "^1.1.0",
     "npm-run-all": "^4.0.2",
     "react-test-renderer": "^15.5.4",
     "rollup": "^0.42.0",
+    "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-filesize": "^1.3.2",


### PR DESCRIPTION
This PR makes it possible to test components by running `npm test`

I wanted to use `buble/register` instead of `babel-register` for the tests, but since buble doesn't have a built-in replacement of the `import` syntax (rollup handles that for us instead), we can only use it for the tests if we use `require`s or some other solution to get it to understand `import`s.

An example test is in components/Button/Button.test.jsx. It relies on `enzyme` and `jsdom` for mounting and simulating a DOM.