### PR TITLE
Remove `uniqueId` requirement from checkbox

### DIFF
--- a/components/Checkbox/Checkbox.jsx
+++ b/components/Checkbox/Checkbox.jsx
@@ -33,8 +33,8 @@ const ToggleCheckbox = () => (
 const Checkbox = props => (
   <div className='form'>
     <fieldset className={getClassName(props)}>
-      <input type='checkbox' checked={props.checked} name={props.uniqueId} value={props.value} onChange={props.onChange} id={props.uniqueId} />
-      <label htmlFor={props.uniqueId}>
+      <input type='checkbox' checked={props.checked} value={props.value} onChange={props.onChange} />
+      <label onClick={props.onChange}>
         <span className='checkbox--contain'>
           { props.type === 'toggle' ? <ToggleCheckbox /> : <StandardCheckbox /> }
           <span className='checkbox--label'>{props.label}</span>
@@ -48,7 +48,6 @@ const Checkbox = props => (
 Checkbox.propTypes = {
   checked: PropTypes.bool,
   label: PropTypes.string,
-  uniqueId: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   size: PropTypes.oneOf([ 'small', 'medium', 'large' ]),
   type: PropTypes.oneOf([ 'standard', 'toggle' ]),

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -62,12 +62,12 @@ const AllComponents = () => (
       </Block>
     </Section>
     <Section title='Checkboxes'>
-      <CheckboxDemo uniqueId='checkbox-demo1' size='small' label='Small' />
-      <CheckboxDemo uniqueId='checkbox-demo2' size='medium' label='Medium' />
-      <CheckboxDemo uniqueId='checkbox-demo3' size='large' label='Large' />
-      <CheckboxDemo uniqueId='checkbox-demo4' size='small' type='toggle' />
-      <CheckboxDemo uniqueId='checkbox-demo5' size='medium' type='toggle' />
-      <CheckboxDemo uniqueId='checkbox-demo6' size='large' type='toggle' />
+      <CheckboxDemo size='small' label='Small' />
+      <CheckboxDemo size='medium' label='Medium' />
+      <CheckboxDemo size='large' label='Large' />
+      <CheckboxDemo size='small' type='toggle' />
+      <CheckboxDemo size='medium' type='toggle' />
+      <CheckboxDemo size='large' type='toggle' />
     </Section>
     <Section title='Radios'>
       <Subtitle>Default</Subtitle>


### PR DESCRIPTION
This PR removes the requirement of a uniqueId from the `<Checkbox>` component.

The reason for this change is that it can be a pain to manage and remember unique ids. Since the only purpose for the `uniqueId` currently is to allow the `<label>` to toggle the checkbox, I think we can do without it.

Of course, the jsx-a11y linter thinks that not having the `htmlFor` property is worse for accessibility (since it doesn't know we are doing the same thing with the `onClick`). If this is an issue, this PR can be rejected since it solves a relatively minor problem.