### PR TITLE
Tags: add tags and example usage

### DIFF
--- a/components/Tag/Tag.jsx
+++ b/components/Tag/Tag.jsx
@@ -1,0 +1,96 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+function getClass(isHover) {
+  return classNames({
+    inline: true,
+    relative: true,
+    'c-tag': true,
+    'is-hover': isHover,
+  });
+}
+
+function getButtonClass(isHover, isProcessing) {
+  return classNames({
+    'c-tag--button': true,
+    'btn-teal': isHover,
+    'is-hover': isHover,
+    'btn-gray': !isHover,
+    'is-processing': isProcessing,
+  });
+}
+
+function getLinkClass(isRemoveHover) {
+  return classNames({
+    'c-tag--remove': true,
+    'icon--center': true,
+    'icon-x-white': true,
+    'icon--xxsmall': true,
+    'btn-red': isRemoveHover,
+    'btn-teal': !isRemoveHover,
+  });
+}
+
+function truncate(str, maxLength) {
+  return str.length > maxLength ? str.slice(0, maxLength).concat('...') : str;
+}
+
+class Tag extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      isHover: false,
+      isRemoveHover: false,
+    };
+    this.setHover = this.setHover.bind(this);
+    this.setRemoveHover = this.setRemoveHover.bind(this);
+  }
+
+  setHover(value) {
+    return () => this.setState({ isHover: value });
+  }
+
+  setRemoveHover(value) {
+    return () => this.setState({ isRemoveHover: value });
+  }
+
+  render() {
+    const { label, maxLength, isProcessing, onClick, onRemove } = this.props;
+    const { isHover, isRemoveHover } = this.state;
+    const { setHover, setRemoveHover } = this;
+    return (
+      <span className={getClass(isHover)} onMouseOver={setHover(true)} onMouseOut={setHover(false)}>
+        <button className={getButtonClass(isHover, isProcessing)} onClick={onClick}>
+          { truncate(label, maxLength) }
+        </button>
+        <a
+          className={getLinkClass(isRemoveHover)}
+          onClick={onRemove}
+          onMouseOver={setRemoveHover(true)}
+          onMouseOut={setRemoveHover(false)}
+        />
+      </span>
+    );
+  }
+
+}
+
+
+Tag.propTypes = {
+  label: PropTypes.string.isRequired,
+  maxLength: PropTypes.number,
+  isProcessing: PropTypes.bool,
+  onClick: PropTypes.func,
+  onRemove: PropTypes.func,
+};
+
+Tag.defaultProps = {
+  maxLength: Infinity,
+  isProcessing: false,
+  onClick: null,
+  onRemove: null,
+};
+
+export default Tag;

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -1,0 +1,3 @@
+import Tag from './Tag.jsx';
+
+export default Tag;

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -11,6 +11,7 @@ import {
 import {
   Button,
   Icon,
+  Tag,
   Text,
 } from '../../index.js';
 
@@ -127,6 +128,10 @@ const AllComponents = () => (
       <RadioDemo buttons items={[{ label: 'Option 1', uniqueId: 'opt1' }, { label: 'Option 2', uniqueId: 'opt2' }]} />
       <Subtitle>Radio buttons with descriptions</Subtitle>
       <RadioDemo buttons items={[{ label: 'Option 1', description: 'Description 1 goes here', uniqueId: 'opt1' }, { label: 'Option 2', description: 'Description 2 goes here', uniqueId: 'opt2' }]} />
+    </Section>
+    <Section title='Tags'>
+      <Block><Tag label='Tag with hover state' onClick={() => alert('Success')} onRemove={() => alert('Removed')} /></Block>
+      <Block><Tag label='Truncated tag' maxLength={12} onClick={() => alert('Success')} onRemove={() => alert('Removed')} /></Block>
     </Section>
     <Section title='Text'>
       <Subtitle>Headings</Subtitle>

--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ import ButtonComponent from './components/Button';
 import CheckboxComponent from './components/Checkbox';
 import IconComponent from './components/Icon';
 import RadioGroupComponent from './components/RadioGroup';
+import TagComponent from './components/Tag';
 import TextComponent from './components/Text';
 
 export const Button = ButtonComponent;
 export const Checkbox = CheckboxComponent;
 export const Icon = IconComponent;
 export const RadioGroup = RadioGroupComponent;
+export const Tag = TagComponent;
 export const Text = TextComponent;


### PR DESCRIPTION
This is the first component that has had to be stateful. The reason I think that is acceptable is because that state is just the hover state that's used internally in the component.

The alternative would be to have a higher-order component manage that state, but unlike checkboxes where a parent component might care about the `checked` value, you probably never will care about the `hover` state.

Some changes from the original Quartz Tag (http://quartz.vhx.tv/js/components) include:
- The `label` is now required. It used to make the label `"Tag"` if one was not passed.
- Changed `onShow` to `onClick` (thoughts?)
- Changed `label_length` to `maxLength`