### PR TITLE
Add test for <Checkbox /> component

### DIFF
--- a/components/Button/Button.test.jsx
+++ b/components/Button/Button.test.jsx
@@ -2,7 +2,7 @@ import jsdom from 'mocha-jsdom';
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import Button from './button';
+import Button from './Button.jsx';
 
 describe('Button', () => {
   jsdom();

--- a/components/Checkbox/Checkbox.test.jsx
+++ b/components/Checkbox/Checkbox.test.jsx
@@ -1,0 +1,30 @@
+import jsdom from 'mocha-jsdom';
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import Checkbox from './Checkbox.jsx';
+
+describe('Checkbox', () => {
+  jsdom();
+
+  it('Renders', () => {
+    const wrapper = mount(<Checkbox uniqueId='checkbox1' />);
+    expect(wrapper.exists()).to.equal(true);
+  });
+
+  it('Defaults to unchecked', () => {
+    const wrapper = mount(<Checkbox uniqueId='checkbox2' />);
+    expect(wrapper.prop('checked')).to.equal(false);
+  });
+
+  it('Can be toggled', () => {
+    let checked = false;
+    const toggle = () => { checked = !checked; };
+    const wrapper = mount(<Checkbox uniqueId='checkbox2' checked={checked} onChange={toggle} />);
+    expect(wrapper.prop('checked')).to.equal(false);
+    wrapper.find('input').simulate('change');
+    expect(checked).to.equal(true);
+    wrapper.find('input').simulate('change');
+    expect(checked).to.equal(false);
+  });
+});


### PR DESCRIPTION
This PR adds a basic test to ensure that the `<Checkbox />` component is functioning properly.

One thing we might look into (but I didn't want to spend too much time on this) is that after simulating the `onChange` event, the `checked` prop did not update within the component (even after trying `wrapper.update()`). I think this might either be an issue with enzyme or the way I am using it, but in reality this does update the component.