### PR TITLE
Created <Input> component

### DIFF
--- a/components/Input/Input.jsx
+++ b/components/Input/Input.jsx
@@ -42,6 +42,7 @@ const Input = props => (
 );
 
 Input.propTypes = {
+  autofocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   error: PropTypes.bool,
@@ -63,6 +64,7 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
+  autofocus: false,
   className: '',
   disabled: false,
   error: false,

--- a/components/Input/Input.jsx
+++ b/components/Input/Input.jsx
@@ -1,0 +1,85 @@
+/* eslint-disable react/no-unused-prop-types */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+function getClass({ className, error, search, small }) {
+  return classNames(className, {
+    small,
+    'is-error': error,
+    'c-select--search': search,
+    'padding-right-large': search,
+    'icon-search-navy': search,
+    'icon--xsmall': search,
+  });
+}
+
+function excludeProps(excludeList, props) {
+  return Object.keys(props)
+    .filter(propName => excludeList.indexOf(propName) === -1)
+    .reduce((finalProps, propName) => {
+      finalProps[propName] = props[propName]; // eslint-disable-line no-param-reassign
+      return finalProps;
+    }, {});
+}
+
+// NOTE: like in the Checkbox component, the `form` class does not
+// do anything here except allow the css selector `.form input` to apply styles.
+// We should consider refactoring the css to remove this requirement.
+const Input = props => (
+  <div className='form'>
+    <input
+      {...excludeProps([ 'className', 'error', 'search', 'small' ], props)}
+      className={getClass({
+        className: props.className,
+        error: props.error,
+        search: props.search,
+        small: props.small,
+      })}
+    />
+  </div>
+);
+
+Input.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  onKeyUp: PropTypes.func,
+  onKeyPress: PropTypes.func,
+  onInput: PropTypes.func,
+  placeholder: PropTypes.string,
+  search: PropTypes.bool,
+  small: PropTypes.bool,
+  style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  type: PropTypes.string,
+  value: PropTypes.string.isRequired,
+};
+
+Input.defaultProps = {
+  className: '',
+  disabled: false,
+  error: false,
+  id: '',
+  name: '',
+  onBlur: null,
+  onChange: null,
+  onFocus: null,
+  onKeyDown: null,
+  onKeyUp: null,
+  onKeyPress: null,
+  onInput: null,
+  placeholder: '',
+  search: false,
+  small: false,
+  style: {},
+  type: 'text',
+};
+
+export default Input;

--- a/components/Input/Input.test.jsx
+++ b/components/Input/Input.test.jsx
@@ -1,0 +1,29 @@
+import jsdom from 'mocha-jsdom';
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import Input from './Input.jsx';
+
+describe('Input', () => {
+  jsdom();
+
+  it('Renders', () => {
+    const wrapper = mount(<Input value='' />);
+    expect(wrapper.exists()).to.equal(true);
+  });
+
+  it('Accepts input events', () => {
+    let callCount = 0;
+    const handleInput = () => callCount++;
+    const wrapper = mount(<Input onInput={handleInput} value='' />);
+    expect(callCount).to.equal(0);
+    wrapper.find('input').simulate('input');
+    expect(callCount).to.equal(1);
+  });
+
+  it('Accepts arbitrary HTML attributes', () => {
+    const wrapper = mount(<Input name='foo' id='123' value='' />);
+    expect(wrapper.find('input').node.getAttribute('name')).to.equal('foo');
+    expect(wrapper.find('input').node.getAttribute('id')).to.equal('123');
+  });
+});

--- a/components/Input/index.js
+++ b/components/Input/index.js
@@ -1,0 +1,3 @@
+import Input from './Input.jsx';
+
+export default Input;

--- a/demo/src/demo-input.jsx
+++ b/demo/src/demo-input.jsx
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import { Input } from '../../index.js';
+
+class StatefulInput extends Component {
+
+  constructor() {
+    super();
+    this.state = { value: '' };
+    this.setValue = this.setValue.bind(this);
+  }
+
+  setValue(event) {
+    this.setState({ value: event.target.value });
+  }
+
+  render() {
+    return (
+      <Input
+        {...this.props}
+        onInput={this.setValue}
+        value={this.state.value}
+      />
+    );
+  }
+}
+
+export default StatefulInput;

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -16,7 +16,7 @@ import {
 
 import CheckboxDemo from './demo-checkbox.jsx';
 import RadioDemo from './demo-radio.jsx';
-
+import InputDemo from './demo-input.jsx';
 
 const AllComponents = () => (
   <div>
@@ -113,6 +113,33 @@ const AllComponents = () => (
           ))
         }
       </ul>
+    </Section>
+    <Section title='Inputs'>
+      <Subtitle>Default input</Subtitle>
+      <InputDemo />
+      <Subtitle>disabled input</Subtitle>
+      <InputDemo disabled />
+      <Subtitle>Error input</Subtitle>
+      <InputDemo error />
+      <Subtitle>Input with placeholder</Subtitle>
+      <InputDemo placeholder='With placeholder' />
+      <Subtitle>Error input with placeholder</Subtitle>
+      <InputDemo error placeholder='With placeholder' />
+      <Subtitle>Password input</Subtitle>
+      <InputDemo type='password' />
+      <Subtitle>Password input with error</Subtitle>
+      <InputDemo type='password' error />
+      <Subtitle>Search input</Subtitle>
+      <InputDemo placeholder='Search' search />
+      <Subtitle>Labeled inputs</Subtitle>
+      { /* by making <Input> a child of <label> we remove the need to create a unique ID */ }
+      <label>
+        <p>Username</p>
+        <InputDemo />
+      </label>
+      { /* the standard usage of <label> will still work if you do not mind making an ID: */ }
+      <label htmlFor='password1'>Password</label>
+      <InputDemo type='password' id='password1' />
     </Section>
     <Section title='Radios'>
       <Subtitle>Default</Subtitle>

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 import ButtonComponent from './components/Button';
 import CheckboxComponent from './components/Checkbox';
 import IconComponent from './components/Icon';
+import InputComponent from './components/Input';
 import RadioGroupComponent from './components/RadioGroup';
 import TextComponent from './components/Text';
 
 export const Button = ButtonComponent;
 export const Checkbox = CheckboxComponent;
 export const Icon = IconComponent;
+export const Input = InputComponent;
 export const RadioGroup = RadioGroupComponent;
 export const Text = TextComponent;


### PR DESCRIPTION
The `<Input>` component, for the most part, just passes on props it receives to an `<input>` element. The benefit to having this as a component is that we get propType checking, and can provide defaults (like `type='text'`) while making it easy to create a search input by just writing `<Input search />` instead of:

```jsx
<input type='text' className='c-select--search padding-right-large icon-search-navy icon--xsmall' />
```

Because we are mostly just passing props through to the input element itself, I wanted to do something like this:

```jsx
<input {...props} />
```

This allows for the most flexibility because we don't have to manually specify every possible html attribute (although I specify some common ones in propTypes so that they can be checked).

The problem with the `{...props}` approach is that we sometimes accept a custom prop, like `search`, that should not be passed to the element.

I decided to try something new to solve this problem and am interested in your thoughts on this. If you like it, it can be added to the utils.

I made an `excludeProps` function that just creates an object that excludes certain keys from a source object. For instance:

```js
excludeProps(['foo', 'bar'], {
  foo: 123,
  bar: 456,
  baz: 789,
  qux: 012
});
```

...returns:

```js
{ baz: 789, qux: 012 }
```

So we get the benefits of being able to pass in `{...props}` without having to put invalid attributes on the html input element.