### PR TITLE
Button: fixed attrs test

### DIFF
--- a/components/Button/Button.test.jsx
+++ b/components/Button/Button.test.jsx
@@ -22,8 +22,8 @@ describe('Button', () => {
   });
 
   it('Accepts arbitrary HTML attributes', () => {
-    const wrapper = mount(<Button height={20} id='123'>foo</Button>);
-    expect(wrapper.props().height).to.equal(20);
-    expect(wrapper.props().id).to.equal('123');
+    const wrapper = mount(<Button attrs={{ height: 20, id: '123' }}>foo</Button>);
+    expect(wrapper.find('button').node.getAttribute('height')).to.equal('20'); // html attrs are coerced to strings
+    expect(wrapper.find('button').node.getAttribute('id')).to.equal('123');
   });
 });


### PR DESCRIPTION
This fixes a broken test for the `<Button>` component.

The fix corrects the test for the current way the `<Button>` is written, but I would like to rewrite the button using the proposed `excludeProps` function in https://github.com/vhx/quartz-react/pull/8 instead of an `attrs` object.

This is related to my comment here: https://github.com/vhx/quartz-react/pull/2

Using `excludeProps` we could write a button like: `<Button id='123'>`
Without it, we have to do: `<Button attrs={{ id: '123' }}>`