### PR TITLE
Util: added utilities and tests, other minor fixes

### DIFF
--- a/components/Button/Button.jsx
+++ b/components/Button/Button.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { excludeProps } from '../util';
 
 function getClassName({ className, color, size, typeface, processing }) {
   return classNames('btn', className, {
@@ -40,13 +41,12 @@ function getClassName({ className, color, size, typeface, processing }) {
 const Button = (props) => {
   const cl = getClassName(props);
   return (
-    <button className={cl} onClick={props.onClick} {...props.attrs}>{props.children}</button>
+    <button className={cl} {...excludeProps([ 'className', 'children', 'color', 'processing', 'size', 'typeface' ], props)}>{props.children}</button>
   );
 };
 
 
 Button.propTypes = {
-  attrs: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
   color: PropTypes.oneOf([ 'gray', 'teal', 'white', 'red', 'purple', 'green', 'slate', 'black', 'yellow', 'transparent', 'twitter', 'facebook', 'tumblr', 'paypal', 'roku' ]),
@@ -57,7 +57,6 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  attrs: {},
   className: '',
   color: 'gray',
   onClick: null,

--- a/components/Button/Button.test.jsx
+++ b/components/Button/Button.test.jsx
@@ -22,7 +22,7 @@ describe('Button', () => {
   });
 
   it('Accepts arbitrary HTML attributes', () => {
-    const wrapper = mount(<Button attrs={{ height: 20, id: '123' }}>foo</Button>);
+    const wrapper = mount(<Button height={20} id={'123'}>foo</Button>);
     expect(wrapper.find('button').node.getAttribute('height')).to.equal('20'); // html attrs are coerced to strings
     expect(wrapper.find('button').node.getAttribute('id')).to.equal('123');
   });

--- a/components/Input/Input.jsx
+++ b/components/Input/Input.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { excludeProps } from '../util';
 
 function getClass({ className, error, search, small }) {
   return classNames(className, {
@@ -13,15 +14,6 @@ function getClass({ className, error, search, small }) {
     'icon-search-navy': search,
     'icon--xsmall': search,
   });
-}
-
-function excludeProps(excludeList, props) {
-  return Object.keys(props)
-    .filter(propName => excludeList.indexOf(propName) === -1)
-    .reduce((finalProps, propName) => {
-      finalProps[propName] = props[propName]; // eslint-disable-line no-param-reassign
-      return finalProps;
-    }, {});
 }
 
 // NOTE: like in the Checkbox component, the `form` class does not
@@ -42,7 +34,7 @@ const Input = props => (
 );
 
 Input.propTypes = {
-  autofocus: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   error: PropTypes.bool,
@@ -64,7 +56,7 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
-  autofocus: false,
+  autoFocus: false,
   className: '',
   disabled: false,
   error: false,

--- a/components/RadioGroup/RadioButton.jsx
+++ b/components/RadioGroup/RadioButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import RadioIcon from './RadioIcon.jsx';
-import If from '../util/If.jsx';
+import { If } from '../util';
 
 function getDescriptionClassName(checked) {
   return classNames({

--- a/components/Tag/Tag.jsx
+++ b/components/Tag/Tag.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { truncate } from '../util';
 
 function getClass(isHover) {
   return classNames({
@@ -32,9 +33,6 @@ function getLinkClass(isRemoveHover) {
   });
 }
 
-function truncate(str, maxLength) {
-  return str.length > maxLength ? str.slice(0, maxLength).concat('...') : str;
-}
 
 class Tag extends Component {
 

--- a/components/util/index.js
+++ b/components/util/index.js
@@ -1,0 +1,45 @@
+import IfComponent from './If.jsx';
+
+
+/*
+<If condition={false}><MyComponent /></If> // MyComponent will not render
+<If condition={true}><MyComponent /></If> // MyComponent will render
+*/
+export const If = IfComponent;
+
+
+/*
+truncate('foo-bar-baz', 4);
+=> 'foo-...'
+
+truncate('foo', 4);
+=> 'foo'
+*/
+export function truncate(str, maxLength) {
+  return str.length > maxLength ? str.slice(0, maxLength).concat('...') : str;
+}
+
+
+/*
+excludeProps(['foo', 'baz'], {
+  foo: 123,
+  bar: 456,
+  baz: 789,
+  qux: 111
+});
+=> { bar: 456, qux: 012 }
+
+This is useful when you want to pass all but a few props to an element. For instance:
+<div {...props}>{props.children}</div> // NO! This is bad because `children` is not a valid html attribute.
+
+For this case, you will want to exclude that prop:
+<div {...excludeProps(['children'], props)}>{props.children}</div> // Much better
+*/
+export function excludeProps(excludeList, props) {
+  return Object.keys(props)
+    .filter(propName => excludeList.indexOf(propName) === -1)
+    .reduce((finalProps, propName) => {
+      finalProps[propName] = props[propName]; // eslint-disable-line no-param-reassign
+      return finalProps;
+    }, {});
+}

--- a/components/util/util.test.jsx
+++ b/components/util/util.test.jsx
@@ -1,0 +1,56 @@
+import jsdom from 'mocha-jsdom';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import {
+  If,
+  truncate,
+  excludeProps,
+} from './index.js';
+
+describe('Utilities', () => {
+  jsdom();
+
+  describe('If', () => {
+    it('Renders children if condition is true', () => {
+      const wrapper = shallow(<If condition={true}>hello!</If>);
+      expect(wrapper.html()).to.include('hello!');
+    });
+
+    it('Does not render children if condition is false', () => {
+      const wrapper = shallow(<If condition={false}>hello!</If>);
+      expect(wrapper.html()).to.not.include('hello!');
+    });
+  });
+
+  describe('truncate', () => {
+    it('Truncates string if past maxLength', () => {
+      expect(truncate('foo-bar-baz', 3)).to.equal('foo...');
+    });
+
+    it('Does nothing if not past maxLength', () => {
+      expect(truncate('foo', 3)).to.equal('foo');
+    });
+  });
+
+  describe('excludeProps', () => {
+    it('Excludes props from object', () => {
+      expect(excludeProps([ 'foo', 'baz' ], {
+        foo: 123,
+        bar: 456,
+        baz: 789,
+        quz: 111,
+      })).to.deep.equal({
+        bar: 456,
+        quz: 111,
+      });
+    });
+
+    it('Does not modify source object', () => {
+      const source = { foo: 123, bar: 456 };
+      const output = excludeProps([ 'foo' ], source);
+      expect(source).to.deep.equal({ foo: 123, bar: 456 });
+      expect(output).to.deep.equal({ bar: 456 });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browser-sync": "^2.18.12",
     "chai": "^4.0.2",
     "enzyme": "^2.8.2",
-    "jsdom": "^11.0.0",
+    "jsdom": "7.0.2",
     "mocha": "^3.4.2",
     "mocha-jsdom": "^1.1.0",
     "npm-run-all": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-register": "^6.24.1",
     "browser-sync": "^2.18.12",
     "chai": "^4.0.2",
+    "enzyme": "^2.8.2",
     "mocha": "^3.4.2",
     "mocha-jsdom": "^1.1.0",
     "npm-run-all": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "browser-sync": "^2.18.12",
     "chai": "^4.0.2",
     "enzyme": "^2.8.2",
+    "jsdom": "^11.0.0",
     "mocha": "^3.4.2",
     "mocha-jsdom": "^1.1.0",
     "npm-run-all": "^4.0.2",


### PR DESCRIPTION
Utilities for components now exist in components/util/index.js, so components can import them with:

`import { someUtility } from '../util'`

In order to make it convenient for developers, the file extension is `.js` instead of `.jsx`, since that would require us to write:

`import { someUtility } from '../util/index.jsx'`

...which is too much typing.

Because of that, all .jsx utilities will need to be imported from their respective files and re-exported. See the `<If>` example. This mirrors the overall structure of the project. (See `index.js` in the root).