### PR TITLE
Header

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-unused-prop-types */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../Icon';

--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -1,0 +1,37 @@
+/* eslint-disable react/no-unused-prop-types */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '../Icon';
+import iconList from '../Icon/icon-list.js';
+
+const Header = ({ border, children, Description, icon, title }) => (
+  <div className={`header row padding-bottom-medium ${border ? 'border-bottom' : ''}`}>
+    <div className='column small-16 medium-8 large-10'>
+      <div className='media'>
+        <div className='media-unit text-top'><Icon name={icon} size='large' /></div>
+        <div className='media-unit media-fill padding-left-medium'>
+          <h2 className='head-3'>{title}</h2>
+          <div className='text text--gray'>{typeof Description === 'string' ? Description : <Description />}</div>
+        </div>
+      </div>
+    </div>
+    <div className='column small-16 medium-8 large-6 text-right'>{children}</div>
+  </div>
+);
+
+Header.propTypes = {
+  border: PropTypes.bool,
+  children: PropTypes.node,
+  Description: PropTypes.oneOfType([ PropTypes.string, PropTypes.func ]), // can be a string or component
+  icon: PropTypes.oneOf(iconList).isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+Header.defaultProps = {
+  border: true,
+  children: null,
+  Description: '',
+};
+
+export default Header;

--- a/components/Header/Header.test.jsx
+++ b/components/Header/Header.test.jsx
@@ -1,0 +1,29 @@
+import jsdom from 'mocha-jsdom';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import Header from './Header.jsx';
+
+describe('Header', () => {
+  jsdom();
+
+  it('Renders', () => {
+    const wrapper = shallow(<Header title='t' icon='cog' />);
+    expect(wrapper.exists()).to.equal(true);
+  });
+
+  it('Accepts description as string', () => {
+    const wrapper = shallow(<Header title='t' icon='cog' Description='foo' />);
+    expect(wrapper.html().includes('foo')).to.equal(true);
+  });
+
+  it('Accepts description as component', () => {
+    const wrapper = shallow(<Header title='t' icon='cog' Description={() => <p>bar</p>} />);
+    expect(wrapper.html().includes('bar')).to.equal(true);
+  });
+
+  it('Renders children', () => {
+    const wrapper = shallow(<Header title='t' icon='cog'><button>baz</button></Header>);
+    expect(wrapper.html().includes('baz')).to.equal(true);
+  });
+});

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -1,0 +1,3 @@
+import Header from './Header.jsx';
+
+export default Header;

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -10,6 +10,7 @@ import {
 
 import {
   Button,
+  Header,
   Icon,
   Tag,
   Text,
@@ -108,6 +109,20 @@ const AllComponents = () => (
       <CheckboxDemo uniqueId='checkbox-demo4' size='small' type='toggle' />
       <CheckboxDemo uniqueId='checkbox-demo5' size='medium' type='toggle' />
       <CheckboxDemo uniqueId='checkbox-demo6' size='large' type='toggle' />
+    </Section>
+    <Section title='Headers'>
+      <Subtitle>Minimal header</Subtitle>
+      <Header title='Section title' icon='product' />
+      <Subtitle>Minimal header without border</Subtitle>
+      <Header title='Section title' icon='product' border={false} />
+      <Subtitle>Header with description</Subtitle>
+      <Header title='Billing' icon='invoice' Description='Review and update your account information' />
+      <Subtitle>Header with description component</Subtitle>
+      <Header title='Product' icon='product' Description={() => <a href='/'>This is a link</a>} />
+      <Subtitle>Header with description and button</Subtitle>
+      <Header title='Section title' icon='download' Description='Foo bar baz'>
+        <Button color='teal'>Bar</Button>
+      </Header>
     </Section>
     <Section title='Icons'>
       <Subtitle>Sizes</Subtitle>

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ export const util = utilities;
 
 export { default as Button } from './components/Button';
 export { default as Checkbox } from './components/Checkbox';
+export { default as Header } from './components/Header';
 export { default as Icon } from './components/Icon';
 export { default as Input } from './components/Input';
 export { default as MediaSelect } from './components/Select/media/Select.jsx';


### PR DESCRIPTION
**Overview:**
This PR creates a `<Header />` component similar to the one seen on http://quartz.vhx.tv/js/components#header.

![screen shot 2017-07-06 at 1 06 29 pm](https://user-images.githubusercontent.com/2024396/27923325-04711a4c-624c-11e7-8c5f-141e4568e5d8.png)

**JIRA task:**
https://vimean.atlassian.net/browse/VHX-1032

**Todo: decide on this...**
The `Header` component accepts a `Description` prop that could be either a string or a component. I could split this into two different props if that would be better. `props.description` (lowercase) would be for passing a string, and `props.Description` would be for passing a component. Thoughts?