### PR TITLE
Sidebar: add component, demo, css, and tests

### DIFF
--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { immutableMerge } from '../util';
 
 const sidebarModel = {
   state: Object.freeze({
@@ -8,14 +9,14 @@ const sidebarModel = {
   }),
   listeners: [],
   close() {
-    sidebarModel.state = Object.freeze(Object.assign({}, sidebarModel.state, { isOpen: false }));
+    sidebarModel.state = immutableMerge(sidebarModel.state, { isOpen: false });
     sidebarModel.notifyListeners();
   },
   open(Children) {
-    sidebarModel.state = Object.freeze(Object.assign({}, sidebarModel.state, {
+    sidebarModel.state = immutableMerge(sidebarModel.state, {
       isOpen: true,
       children: <Children />,
-    }));
+    });
     sidebarModel.notifyListeners();
   },
   toggle(Children) {

--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -1,0 +1,91 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const sidebarModel = {
+  state: Object.freeze({
+    isOpen: false,
+    children: null,
+  }),
+  listeners: [],
+  close() {
+    sidebarModel.state = Object.assign({}, sidebarModel.state, { isOpen: false });
+    sidebarModel.notifyListeners();
+  },
+  open(Children) {
+    sidebarModel.state = Object.assign({}, sidebarModel.state, {
+      isOpen: true,
+      children: <Children />,
+    });
+    sidebarModel.notifyListeners();
+  },
+  toggle(Children) {
+    if (sidebarModel.state.isOpen) {
+      sidebarModel.close();
+    } else {
+      sidebarModel.open(Children);
+    }
+  },
+  subscribe(fn) {
+    if (sidebarModel.listeners.indexOf(fn) === -1) {
+      sidebarModel.listeners.push(fn);
+    }
+  },
+  unsubscribe(fn) {
+    const index = sidebarModel.listeners.indexOf(fn);
+    if (index === -1) { return; }
+    sidebarModel.listeners.splice(index, 1);
+  },
+  notifyListeners() {
+    sidebarModel.listeners.forEach(fn => fn(sidebarModel.state));
+  },
+};
+
+
+let sidebarIsInitialized = false;
+class Sidebar extends Component {
+  constructor() {
+    super();
+    this.state = sidebarModel.state;
+    this.update = this.update.bind(this);
+  }
+
+  componentWillMount() {
+    if (sidebarIsInitialized) {
+      console.warn('Sidebar has already been instanciated. There should only be one sidebar component mounted at any given time.');
+    }
+    sidebarIsInitialized = true;
+    sidebarModel.subscribe(this.update);
+  }
+
+  componentWillUnmount() {
+    sidebarIsInitialized = false;
+    sidebarModel.unsubscribe(this.update);
+  }
+
+  update(state) {
+    this.setState(state);
+  }
+
+  render() {
+    return (
+      <div className={`sidebar c-sidebar bg-white shadow--gray ${this.state.isOpen ? 'sidebar--open' : ''}`}>
+        <a className='c-sidebar--close icon-circle icon-x-navy icon--xsmall' onClick={() => sidebarModel.close()} />
+        <div>{this.state.children}</div>
+      </div>
+    );
+  }
+}
+
+Sidebar.propTypes = {
+  isOpen: PropTypes.bool,
+};
+
+Sidebar.defaultProps = {
+  isOpen: false,
+};
+
+Sidebar.close = sidebarModel.close;
+Sidebar.open = sidebarModel.open;
+Sidebar.toggle = sidebarModel.toggle;
+
+export default Sidebar;

--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -8,14 +8,14 @@ const sidebarModel = {
   }),
   listeners: [],
   close() {
-    sidebarModel.state = Object.assign({}, sidebarModel.state, { isOpen: false });
+    sidebarModel.state = Object.freeze(Object.assign({}, sidebarModel.state, { isOpen: false }));
     sidebarModel.notifyListeners();
   },
   open(Children) {
-    sidebarModel.state = Object.assign({}, sidebarModel.state, {
+    sidebarModel.state = Object.freeze(Object.assign({}, sidebarModel.state, {
       isOpen: true,
       children: <Children />,
-    });
+    }));
     sidebarModel.notifyListeners();
   },
   toggle(Children) {
@@ -87,5 +87,6 @@ Sidebar.defaultProps = {
 Sidebar.close = sidebarModel.close;
 Sidebar.open = sidebarModel.open;
 Sidebar.toggle = sidebarModel.toggle;
+Sidebar.model = sidebarModel;
 
 export default Sidebar;

--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -51,7 +51,7 @@ class Sidebar extends Component {
 
   componentWillMount() {
     if (sidebarIsInitialized) {
-      console.warn('Sidebar has already been instanciated. There should only be one sidebar component mounted at any given time.');
+      console.warn('Sidebar has already been instantiated. There should only be one sidebar component mounted at any given time.');
     }
     sidebarIsInitialized = true;
     sidebarModel.subscribe(this.update);

--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -2,10 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { immutableMerge } from '../util';
 
+const EmptyComponent = () => <span />;
+
 const sidebarModel = {
   state: Object.freeze({
     isOpen: false,
-    children: null,
+    children: EmptyComponent,
   }),
   listeners: [],
   close() {
@@ -13,10 +15,9 @@ const sidebarModel = {
     sidebarModel.notifyListeners();
   },
   open(Children) {
-    sidebarModel.state = immutableMerge(sidebarModel.state, {
-      isOpen: true,
-      children: <Children />,
-    });
+    sidebarModel.state = Children ?
+      immutableMerge(sidebarModel.state, { isOpen: true, children: <Children /> }) :
+      immutableMerge(sidebarModel.state, { isOpen: true });
     sidebarModel.notifyListeners();
   },
   toggle(Children) {

--- a/components/Sidebar/Sidebar.test.jsx
+++ b/components/Sidebar/Sidebar.test.jsx
@@ -7,6 +7,10 @@ import Sidebar from './Sidebar.jsx';
 describe('Sidebar', () => {
   jsdom();
 
+  afterEach(() => {
+    Sidebar.close();
+  });
+
   it('Renders', () => {
     const wrapper = shallow(<Sidebar />);
     expect(wrapper.exists()).to.equal(true);
@@ -37,5 +41,60 @@ describe('Sidebar', () => {
     expect(wrapper.state().isOpen).to.equal(false);
     Sidebar.toggle(Children);
     expect(wrapper.state().isOpen).to.equal(true);
+  });
+
+  describe('Sidebar model', () => {
+    it('Is possible to access current state', () => {
+      const Children = () => <div />;
+      expect(Sidebar.model.state.isOpen).to.equal(false);
+      Sidebar.toggle(Children);
+      expect(Sidebar.model.state.isOpen).to.equal(true);
+      Sidebar.toggle(Children);
+      expect(Sidebar.model.state.isOpen).to.equal(false);
+    });
+
+    it('Cannot directly manipulate state', () => {
+      expect(Sidebar.model.state.isOpen).to.equal(false);
+      expect(() => {
+        Sidebar.model.state.isOpen = true;
+      }).to.throw();
+    });
+
+    it('Can subscribe to state changes', () => {
+      let callCount = 0;
+      const Children = () => <div />;
+      function onUpdate(state) {
+        expect(typeof state.isOpen).to.equal('boolean');
+        callCount++;
+      }
+      Sidebar.model.subscribe(onUpdate);
+      Sidebar.open(Children);
+      Sidebar.close();
+      Sidebar.toggle(Children);
+      expect(callCount).to.equal(3);
+      Sidebar.model.unsubscribe(onUpdate);
+    });
+
+    it('Can unsubscribe from changes', () => {
+      let callCount = 0;
+      const Children = () => <div />;
+      function onUpdate(state) {
+        expect(typeof state.isOpen).to.equal('boolean');
+        callCount++;
+      }
+      Sidebar.model.subscribe(onUpdate);
+      Sidebar.open(Children);
+      Sidebar.close();
+      Sidebar.toggle(Children);
+      expect(callCount).to.equal(3);
+      Sidebar.model.unsubscribe(onUpdate);
+      Sidebar.close();
+      Sidebar.close();
+      Sidebar.close();
+      Sidebar.close();
+      Sidebar.close();
+      Sidebar.close();
+      expect(callCount).to.equal(3);
+    });
   });
 });

--- a/components/Sidebar/Sidebar.test.jsx
+++ b/components/Sidebar/Sidebar.test.jsx
@@ -1,0 +1,41 @@
+import jsdom from 'mocha-jsdom';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import Sidebar from './Sidebar.jsx';
+
+describe('Sidebar', () => {
+  jsdom();
+
+  it('Renders', () => {
+    const wrapper = shallow(<Sidebar />);
+    expect(wrapper.exists()).to.equal(true);
+  });
+
+  it('Defaults to closed state', () => {
+    const wrapper = shallow(<Sidebar />);
+    expect(wrapper.state().isOpen).to.equal(false);
+  });
+
+  it('Can be opened / closed / toggled', () => {
+    const wrapper = shallow(<Sidebar />);
+    expect(wrapper.state().isOpen).to.equal(false);
+
+    // open:
+    const Children = () => <div />;
+    Sidebar.open(Children);
+    expect(wrapper.state().isOpen).to.equal(true);
+
+    // close:
+    Sidebar.close();
+    expect(wrapper.state().isOpen).to.equal(false);
+
+    // toggle:
+    Sidebar.toggle(Children);
+    expect(wrapper.state().isOpen).to.equal(true);
+    Sidebar.toggle(Children);
+    expect(wrapper.state().isOpen).to.equal(false);
+    Sidebar.toggle(Children);
+    expect(wrapper.state().isOpen).to.equal(true);
+  });
+});

--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -1,0 +1,3 @@
+import Sidebar from './Sidebar.jsx';
+
+export default Sidebar;

--- a/components/Text/Text.jsx
+++ b/components/Text/Text.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 function getClassName(props) {
-  return classNames({
+  return classNames(props.className, {
     block: Boolean(props.block),
     'head-1': Boolean(props.h1),
     'head-2': Boolean(props.h2),
@@ -31,6 +31,7 @@ Text.propTypes = {
   h3: PropTypes.bool,
   h4: PropTypes.bool,
   h5: PropTypes.bool,
+  className: PropTypes.string,
   color: PropTypes.oneOf([ 'navy', 'gray', 'teal', 'white' ]),
 };
 
@@ -41,6 +42,7 @@ Text.defaultProps = {
   h3: false,
   h4: false,
   h5: false,
+  className: '',
   color: 'navy',
 };
 

--- a/components/util/index.js
+++ b/components/util/index.js
@@ -103,3 +103,8 @@ export function getAspectRatioHeight(aspectRatio, width) {
   const height = width / (w / h);
   return Math.floor(height); // round down to prevent possible single pixel black line
 }
+
+
+export function immutableMerge(...args) {
+  return Object.freeze(Object.assign({}, ...args));
+}

--- a/components/util/util.test.jsx
+++ b/components/util/util.test.jsx
@@ -9,6 +9,7 @@ import {
   select,
   multiSelect,
   getAspectRatioHeight,
+  immutableMerge,
 } from './index.js';
 
 describe('Utilities', () => {
@@ -99,6 +100,19 @@ describe('Utilities', () => {
       expect(getAspectRatioHeight('16:9', 1280)).to.equal(720);
       expect(getAspectRatioHeight('16:7', 1280)).to.equal(560);
       expect(getAspectRatioHeight('16:6', 1920)).to.equal(720);
+    });
+  });
+
+  describe('immutableMerge', () => {
+    it('Merges objects and freezes', () => {
+      const x = { foo: 123 };
+      const y = { foo: 456, bar: 567 };
+      const z = { baz: 789 };
+      const merged = immutableMerge(x, y, z);
+      expect(x).to.deep.equal({ foo: 123 });
+      expect(y).to.deep.equal({ foo: 456, bar: 567 });
+      expect(z).to.deep.equal({ baz: 789 });
+      expect(merged).to.deep.equal({ foo: 456, bar: 567, baz: 789 });
     });
   });
 });

--- a/demo/public/css/sidebar.css
+++ b/demo/public/css/sidebar.css
@@ -1,0 +1,10 @@
+.sidebar {
+  right: -470px;
+  transform: translate3d(0, 0, 0);
+  transition: transform 400ms ease;
+}
+
+.sidebar.sidebar--open {
+  transform: translate3d(-470px, 0, 0);
+  transition: transform 400ms ease;
+}

--- a/demo/public/css/sidebar.css
+++ b/demo/public/css/sidebar.css
@@ -1,10 +1,12 @@
 .sidebar {
-  right: -470px;
+  max-width: 100%;
+  right: -608px;
   transform: translate3d(0, 0, 0);
   transition: transform 400ms ease;
+  width: 600px;
 }
 
 .sidebar.sidebar--open {
-  transform: translate3d(-470px, 0, 0);
+  transform: translate3d(-608px, 0, 0);
   transition: transform 400ms ease;
 }

--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/css/demo.css">
   <link rel="stylesheet" href="/css/carousel.css">
   <link rel="stylesheet" href="/css/slide.css">
+  <link rel="stylesheet" href="/css/sidebar.css">
   <script>
     (function() {
     var config = { kitId: 'mee1sll', scriptTimeout: 3000 };

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -9,9 +9,10 @@ import Checkboxes from './sections/Checkboxes.jsx';
 import Icons from './sections/Icons.jsx';
 import Inputs from './sections/Inputs.jsx';
 import Radios from './sections/Radios.jsx';
+import Selects from './sections/Selects.jsx';
+import Sidebars from './sections/Sidebars.jsx';
 import Tags from './sections/Tags.jsx';
 import Text from './sections/TextDemo.jsx';
-import Selects from './sections/Selects.jsx';
 
 const sections = {
   Buttons,
@@ -21,6 +22,7 @@ const sections = {
   Inputs,
   'Radio Groups': Radios,
   Selects,
+  Sidebars,
   Tags,
   Text,
 };

--- a/demo/src/sections/Sidebars.jsx
+++ b/demo/src/sections/Sidebars.jsx
@@ -11,6 +11,7 @@ import {
 } from '../ui';
 
 const SidebarChildren = () => <div>Sidebar children go here</div>;
+
 const OtherSidebarChildren = () => (
   <div>
     <div>Here is some different content for the sidebar</div>

--- a/demo/src/sections/Sidebars.jsx
+++ b/demo/src/sections/Sidebars.jsx
@@ -30,7 +30,8 @@ const SidebarDemo = () => (
     <Block><Button onClick={() => Sidebar.toggle(OtherSidebarChildren)}>Toggle sidebar 2</Button></Block>
     <Hr />
     <Block><Button onClick={() => Sidebar.close()}>Close all sidebars</Button></Block>
-    <Block><Button onClick={() => Sidebar.open()}>Reopen last closed sidebar</Button></Block>
+    <Block><Button onClick={() => Sidebar.open()}>Reopen most recent sidebar</Button></Block>
+    <Block><Button onClick={() => Sidebar.toggle()}>Toggle most recent sidebar</Button></Block>
   </div>
 );
 
@@ -52,7 +53,11 @@ const Children = () => (
 </Button>
 
 <Button onClick={() => Sidebar.open()}>
-  Reopen last closed sidebar
+  Reopen most recent sidebar
+</Button>
+
+<Button onClick={() => Sidebar.toggle()}>
+  Toggle most recent sidebar
 </Button>
 `;
 

--- a/demo/src/sections/Sidebars.jsx
+++ b/demo/src/sections/Sidebars.jsx
@@ -30,6 +30,7 @@ const SidebarDemo = () => (
     <Block><Button onClick={() => Sidebar.toggle(OtherSidebarChildren)}>Toggle sidebar 2</Button></Block>
     <Hr />
     <Block><Button onClick={() => Sidebar.close()}>Close all sidebars</Button></Block>
+    <Block><Button onClick={() => Sidebar.open()}>Reopen last closed sidebar</Button></Block>
   </div>
 );
 
@@ -48,6 +49,10 @@ const Children = () => (
 
 <Button onClick={() => Sidebar.toggle(Children)}>
   Toggle sidebar
+</Button>
+
+<Button onClick={() => Sidebar.open()}>
+  Reopen last closed sidebar
 </Button>
 `;
 
@@ -76,6 +81,10 @@ Sidebar.toggle(ChildComponent);`
         The <code>&lt;Sidebar /&gt;</code> component accepts no props or children and should be initialized
         only <strong>once</strong> in the root component of your app. After this initialization,
         it will manage itself and respond only to updates through its method calls.
+      </Details>
+      <Details>
+        Calling any <code>Sidebar.open()</code> or <code>Sidebar.toggle()</code> without any arguments
+        will reopen or toggle the sidebar with the most recently used children.
       </Details>
     </DemoRow>
     <DemoRow code={sidebarCode}><SidebarDemo /></DemoRow>

--- a/demo/src/sections/Sidebars.jsx
+++ b/demo/src/sections/Sidebars.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Sidebar } from '../../../index.js';
+import {
+  Block,
+  DemoRow,
+  Details,
+  Hr,
+  Subtitle,
+  Title,
+} from '../ui';
+
+const SidebarChildren = () => <div>Sidebar children go here</div>;
+const OtherSidebarChildren = () => (
+  <div>
+    <div>Here is some different content for the sidebar</div>
+    <img src='/images/1.jpg' alt='yum' />
+  </div>
+);
+
+const SidebarDemo = () => (
+  <div>
+    <Subtitle>Sidebar Demo</Subtitle>
+    <Sidebar />
+    <Block><Button onClick={() => Sidebar.open(SidebarChildren)}>Open sidebar 1</Button></Block>
+    <Block><Button onClick={() => Sidebar.toggle(SidebarChildren)}>Toggle sidebar 1</Button></Block>
+    <Hr />
+    <Block><Button onClick={() => Sidebar.open(OtherSidebarChildren)}>Open sidebar 2</Button></Block>
+    <Block><Button onClick={() => Sidebar.toggle(OtherSidebarChildren)}>Toggle sidebar 2</Button></Block>
+    <Hr />
+    <Block><Button onClick={() => Sidebar.close()}>Close all sidebars</Button></Block>
+  </div>
+);
+
+const sidebarCode = `
+const Children = () => (
+  <div>Sidebar children go here</div>
+);
+
+<Button onClick={() => Sidebar.open(Children)}>
+  Open sidebar
+</Button>
+
+<Button onClick={() => Sidebar.close()}>
+  Close sidebar
+</Button>
+
+<Button onClick={() => Sidebar.toggle(Children)}>
+  Toggle sidebar
+</Button>
+`;
+
+
+// Main exported demo
+// -----------------------------------------
+
+const Sidebars = ({ title }) => (
+  <div>
+    <DemoRow>
+      <Title>{title}</Title>
+      <Details>
+        <strong>Important:</strong> You probably do not want to use the <code>Sidebar</code> as a component!
+        Use its static methods:
+        <pre className='code'>
+          {
+`Sidebar.open(ChildComponent);
+Sidebar.close();
+Sidebar.toggle(ChildComponent);`
+          }
+        </pre>
+        If you do intend to use the component (ie. you are adding a sidebar to an application that does
+        not yet have any sidebars) then read on.
+      </Details>
+      <Details>
+        The <code>&lt;Sidebar /&gt;</code> component accepts no props or children and should be initialized
+        only <strong>once</strong> in the root component of your app. After this initialization,
+        it will manage itself and respond only to updates through its method calls.
+      </Details>
+    </DemoRow>
+    <DemoRow code={sidebarCode}><SidebarDemo /></DemoRow>
+  </div>
+);
+
+Sidebars.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default Sidebars;

--- a/demo/src/ui/Hr.jsx
+++ b/demo/src/ui/Hr.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Hr = () => (
+  <div className='border-bottom border--gray-light margin-vert-small' />
+);
+
+export default Hr;

--- a/demo/src/ui/index.js
+++ b/demo/src/ui/index.js
@@ -1,6 +1,7 @@
 export { default as Block } from './Block.jsx';
 export { default as DemoRow } from './DemoRow.jsx';
 export { default as Details } from './Details.jsx';
+export { default as Hr } from './Hr.jsx';
 export { default as Nav } from './Nav.jsx';
 export { default as Subtitle } from './Subtitle.jsx';
 export { default as Title } from './Title.jsx';

--- a/dist/demo.css
+++ b/dist/demo.css
@@ -1,0 +1,110 @@
+/*
+  Quartz-react version: 0.0.1
+  Current file hash: 1b9a1a73053e8c1ff0f9fe7349e22367
+*/
+
+.nav-primary {
+  background: #f7f8f9;
+  border-right: 1px solid #f0f2f4;
+  height: 100%;
+  left: 0;
+  overflow-y: auto;
+  position: fixed;
+  text-indent: 30px;
+  top: 0;
+  width: 225px;
+  z-index: 1;
+}
+
+.nav-primary a {
+  line-height: 40px;
+}
+
+.nav-primary a:focus,
+.nav-primary a:hover {
+  background: #d7dde1;
+}
+
+.stage {
+  background: #2d2d2d;
+  margin-left: 225px;
+}
+
+.guide-bar {
+  background: #fff;
+  position: relative;
+  padding: 35px 65px;
+}
+
+.demo-list {
+  list-style: disc;
+  padding: 10px 20px;
+}
+
+.details pre.code {
+  margin: 10px 0;
+}
+
+.details .code,
+.details code {
+  background: #f7f8f9;
+  border-radius: 3px;
+  font-family: Menlo, Monaco, 'Andale Mono', 'Lucida Console', 'Courier New', monospace;
+  font-size: 13px;
+  padding: 2px 4px;
+}
+
+.code-bar {
+  background: #2d2d2d;
+  color: #fff;
+  display: block;
+  font-size: 13px !important;
+  font-family: Menlo, Monaco, 'Andale Mono', 'Lucida Console', 'Courier New', monospace;
+  overflow-x: auto;
+  overflow-wrap: break-word !important;
+  padding: 35px;
+  -webkit-text-size-adjust: none;
+}
+
+
+/* ------------------ prism js ------------------- */
+
+/* .tag is used in Quartz, and this prism class conflicts with it, so these are a few overrides: */
+.code-bar .tag,
+.code-bar .tag:active,
+.code-bar .tag:focus,
+.code-bar .tag:hover {
+  background-color: transparent !important;
+  border: 0;
+  color: #e87d84;
+  font-size: 14px;
+  opacity: 1;
+  padding: 0;
+}
+
+.code-bar .boolean,
+.code-bar .number,
+.code-bar .attr-name {
+  color: #f7c36f;
+}
+
+.code-bar .function,
+.code-bar .property,
+.code-bar .keyword {
+  color: #93ddf5;
+}
+
+.code-bar .attr-value,
+.code-bar .selector,
+.code-bar .string {
+  color: #b3ea4d;
+}
+
+.code-bar .operator,
+.code-bar .punctuation {
+  color: #c1e0ff;
+}
+
+.code-bar .comment {
+  color: #7d9bb9;
+}

--- a/dist/quartz-react.js
+++ b/dist/quartz-react.js
@@ -136,6 +136,14 @@ function getAspectRatioHeight(aspectRatio, width) {
 }
 
 
+function immutableMerge() {
+  var args = [], len = arguments.length;
+  while ( len-- ) args[ len ] = arguments[ len ];
+
+  return Object.freeze(Object.assign.apply(Object, [ {} ].concat( args )));
+}
+
+
 var utilities = Object.freeze({
 	truncate: truncate,
 	excludeProps: excludeProps,
@@ -143,6 +151,7 @@ var utilities = Object.freeze({
 	select: select,
 	typoPropType: typoPropType,
 	getAspectRatioHeight: getAspectRatioHeight,
+	immutableMerge: immutableMerge,
 	If: If
 });
 
@@ -1191,21 +1200,22 @@ var Select = SelectHOC({
   type: 'standard', // NOTE: 'standard' isn't used anywhere, just specifying that it's not 'media'
 });
 
+var EmptyComponent = function () { return React__default.createElement( 'span', null ); };
+
 var sidebarModel = {
   state: Object.freeze({
     isOpen: false,
-    children: null,
+    children: EmptyComponent,
   }),
   listeners: [],
   close: function close() {
-    sidebarModel.state = Object.assign({}, sidebarModel.state, { isOpen: false });
+    sidebarModel.state = immutableMerge(sidebarModel.state, { isOpen: false });
     sidebarModel.notifyListeners();
   },
   open: function open(Children) {
-    sidebarModel.state = Object.assign({}, sidebarModel.state, {
-      isOpen: true,
-      children: React__default.createElement( Children, null ),
-    });
+    sidebarModel.state = Children ?
+      immutableMerge(sidebarModel.state, { isOpen: true, children: React__default.createElement( Children, null ) }) :
+      immutableMerge(sidebarModel.state, { isOpen: true });
     sidebarModel.notifyListeners();
   },
   toggle: function toggle(Children) {
@@ -1245,7 +1255,7 @@ var Sidebar$1 = (function (Component$$1) {
 
   Sidebar.prototype.componentWillMount = function componentWillMount () {
     if (sidebarIsInitialized) {
-      console.warn('Sidebar has already been instanciated. There should only be one sidebar component mounted at any given time.');
+      console.warn('Sidebar has already been instantiated. There should only be one sidebar component mounted at any given time.');
     }
     sidebarIsInitialized = true;
     sidebarModel.subscribe(this.update);
@@ -1283,6 +1293,7 @@ Sidebar$1.defaultProps = {
 Sidebar$1.close = sidebarModel.close;
 Sidebar$1.open = sidebarModel.open;
 Sidebar$1.toggle = sidebarModel.toggle;
+Sidebar$1.model = sidebarModel;
 
 var MAX_TITLE_LENGTH = 50; // characters
 

--- a/dist/sidebar.css
+++ b/dist/sidebar.css
@@ -1,0 +1,15 @@
+/*
+  Quartz-react version: 0.0.1
+  Current file hash: 9d4936db03182d07a846a1efb9e779bf
+*/
+
+.sidebar {
+  right: -470px;
+  transform: translate3d(0, 0, 0);
+  transition: transform 400ms ease;
+}
+
+.sidebar.sidebar--open {
+  transform: translate3d(-470px, 0, 0);
+  transition: transform 400ms ease;
+}

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ export { default as Input } from './components/Input';
 export { default as MediaSelect } from './components/Select/media/Select.jsx';
 export { default as RadioGroup } from './components/RadioGroup';
 export { default as Select } from './components/Select/standard/Select.jsx';
+export { default as Sidebar } from './components/Sidebar';
 export { default as Slide } from './components/Slide';
 export { default as Tag } from './components/Tag';
 export { default as Text } from './components/Text';


### PR DESCRIPTION
### Overview

This PR adds a `<Sidebar />` component and the following methods to interact with it:

- `Sidebar.close()`
- `Sidebar.open(ChildComponent?)`
- `Sidebar.toggle(ChildComponent?)`

A `ChildComponent` is optional in the `open` and `toggle` methods. If not present, the sidebar will be opened with the contents of the most recently opened sidebar.

The intended use is to have a single `<Sidebar />` instantiated at the root level component. Then whenever a sidebar is to be opened, that can be done by calling one of the static methods.

![screen shot 2017-07-11 at 4 36 32 pm](https://user-images.githubusercontent.com/2024396/28089486-22d10916-6657-11e7-9a61-ba5e37651bb3.png)

---

### Changes from current sidebar:
1. The width is 600px rather than 462px
2. The sidebar does not close when clicking elsewhere on the page **(Needs discussion!)**
3. It does not include a "loading" state. (Children have to determine their own state)

### Implementation details:
Both the `<Sidebar>` component and its static methods have to be aware of the same state. This is only possible if the state is kept outside of the component.

The simplest way I could think of achieving this was for the state to be shared in an stream-like model. When the model updates, the component updates itself.

This has some benefits:
1. It does not couple the component to our state management library. We could start with redux only to later switch to something else and not have to worry about updating quartz-react. (Or one project could use redux and another could use mobx, but both could use quartz-react.)
2. By exposing the model, it's trivial to connect the sidebar state to a redux or mobx store. You would do something like this:

```
Sidebar.model.subscribe(function(sidebarState) {
  // if using redux:
  dispatch({
    type: 'SIDEBAR_UPDATED',
    isOpen: sidebarState.isOpen
  });
});
```
And if you don't care about having the sidebar's state in your state tree, then you don't have to do anything.