### PR TITLE
Select: fixed the bug

### DIFF
--- a/components/Select/media/SelectDropdownOption.jsx
+++ b/components/Select/media/SelectDropdownOption.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Icon from '../../Icon';
 import { If, truncate } from '../../util';
 
 const imgStyle = url => ({
@@ -14,9 +13,9 @@ function getButton(isProcessing, isSelected) {
     return <div className='c-item-toggle loader-white loader--small' />;
   }
   if (isSelected) {
-    return <Icon size='xsmall' name='check' color='navy' className='block c-item-toggle border is-selected' button />;
+    return <div className='c-item-toggle icon-check-navy icon--xsmall border is-selected' />;
   }
-  return <Icon size='xsmall' name='plus-thin' color='white' className='block c-item-toggle border' button />;
+  return <div className='c-item-toggle icon-plus-thin-white icon--xsmall border' />;
 }
 
 const MediaSelectDropdownOption = ({ description, imageUrl, isLoading, isProcessingItem, isSelected, label, maxLabelLength, multiSelect, onOptionToggle, uniqueId }) => (


### PR DESCRIPTION
Fixes #21 

The logic that handles closing the `<Select>` when you click anywhere outside of it is defined here:
https://github.com/vhx/quartz-react/blob/c273700268d97463e36496657271830a3dcd6ac2/components/Select/SelectHOC.jsx#L36-L50

The bug was caused by checking `!this.element.contains(event.target)`.

In this case, React already removed `event.target` from the DOM by the time the event listener could fire. This is because React, in reconciling the diff between a `<div>` and an `<Icon>` in [this function](https://github.com/vhx/quartz-react/blob/c273700268d97463e36496657271830a3dcd6ac2/components/Select/media/SelectDropdownOption.jsx#L12-L20), determined that the element should be replaced rather than updated. By instead keeping the returned element type of `getButton()` consistent, the element doesn't get incorrectly removed from the DOM, which fixes this bug.