### PR TITLE
Chore: add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules/
 
 # The bundle is generated with npm run demo
 demo/public/js/*
+
+# Code coverage reports are generated and do not need to be checked into git
+coverage/
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "rollup -c build/rollup.demo-config.js --watch",
     "serve": "browser-sync start --server --serveStatic \"demo/public\" --files \"demo/public/js/bundle.js\" --no-open",
     "start": "npm-run-all --parallel dev serve",
-    "test": "mocha components/**/*.test.jsx --compilers js:babel-register"
+    "test": "nyc --extension .jsx --reporter=html --reporter=text-summary mocha components/**/*.test.jsx --compilers js:babel-register"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "mocha": "^3.4.2",
     "mocha-jsdom": "^1.1.0",
     "npm-run-all": "^4.0.2",
+    "nyc": "^11.0.3",
     "react-test-renderer": "^15.5.4",
     "rollup": "^0.42.0",
     "rollup-plugin-babel": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "rollup -c build/rollup.demo-config.js --watch",
     "serve": "browser-sync start --server --serveStatic \"demo/public\" --files \"demo/public/js/bundle.js\" --no-open",
     "start": "npm-run-all --parallel dev serve",
-    "test": "nyc --extension .jsx --reporter=html --reporter=text-summary mocha components/**/*.test.jsx --compilers js:babel-register"
+    "test": "nyc --extension .jsx --reporter=html --reporter=text-summary mocha components/**/*.test.jsx --compilers js:babel-register",
+    "test:nocover": "mocha components/**/*.test.jsx --compilers js:babel-register"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds generated code coverage reports. This is helpful when writing tests for components, since it can be easy to slip up and forget to test certain cases.

It would also be nice to have something like codeclimate setup for this repo since we have it setup for other repos. We could then output a coverage report to the `lcov` format that codeclimate reads.