### PR TITLE
Feature/Carousel: add coin drop shadow

### DIFF
--- a/demo/public/css/carousel.css
+++ b/demo/public/css/carousel.css
@@ -85,6 +85,7 @@
   background: #fff;
   border: 0;
   borderRadius: 4px; /* 50% of height */
+  box-shadow: 0 1px 5px #000;
   height: 8px;
   margin: 0 4px;
   opacity: 0.5;

--- a/dist/carousel.css
+++ b/dist/carousel.css
@@ -1,6 +1,6 @@
 /*
-  Quartz-react version: 0.0.1
-  Current file hash: 8132acd1934f424225855b6045b89081
+  Quartz-react version: 0.0.3
+  Current file hash: 064240763173612ae21da9cf52848651
 */
 
 .carousel {
@@ -90,6 +90,7 @@
   background: #fff;
   border: 0;
   borderRadius: 4px; /* 50% of height */
+  box-shadow: 0 1px 5px #000;
   height: 8px;
   margin: 0 4px;
   opacity: 0.5;

--- a/dist/demo.css
+++ b/dist/demo.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.1
+  Quartz-react version: 0.0.3
   Current file hash: 1b9a1a73053e8c1ff0f9fe7349e22367
 */
 

--- a/dist/sidebar.css
+++ b/dist/sidebar.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.1
+  Quartz-react version: 0.0.3
   Current file hash: 84597099e5e0f8f7fecadfd205ab51f2
 */
 

--- a/dist/slide.css
+++ b/dist/slide.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.1
+  Quartz-react version: 0.0.3
   Current file hash: 3ea776fd3ad9615fe3050c37a41c0eb5
 */
 


### PR DESCRIPTION
This PR adds a subtle shadow to the navigation coins in the `<Carousel />` component. This prevents them from being invisible when the slide's background image is white.

Only one line was added. The rest of the noise in the PR is from running the build script.