### PR TITLE
Update mobile breakpoint classnames

### DIFF
--- a/demo/src/ui/DemoRow.jsx
+++ b/demo/src/ui/DemoRow.jsx
@@ -22,10 +22,10 @@ class DemoRow extends Component {
   render() {
     return (
       <div className='row'>
-        <div className='column small-8 padding-reset'>
+        <div className='column small-8 medium-9 large-10 padding-reset'>
           <div className='guide-bar' style={{ minHeight: `${this.state.codeHeight}px` }}>{this.props.children}</div>
         </div>
-        <div className='column small-8 padding-reset' ref={this.setHeightOnce}>
+        <div className='column small-8 medium-7 large-6 padding-reset' ref={this.setHeightOnce}>
           <div className='code-bar'>
             <pre className='padding-medium'>
               <code dangerouslySetInnerHTML={this.markupCode()} />

--- a/demo/src/ui/DemoRow.jsx
+++ b/demo/src/ui/DemoRow.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { util } from '../../../index.js';
+
+const { If } = util;
 
 class DemoRow extends Component {
   constructor() {
@@ -22,16 +25,18 @@ class DemoRow extends Component {
   render() {
     return (
       <div className='row'>
-        <div className='column small-8 medium-9 large-10 padding-reset'>
+        <div className='column medium-16 large-10 xlarge-11 padding-reset'>
           <div className='guide-bar' style={{ minHeight: `${this.state.codeHeight}px` }}>{this.props.children}</div>
         </div>
-        <div className='column small-8 medium-7 large-6 padding-reset' ref={this.setHeightOnce}>
-          <div className='code-bar'>
-            <pre className='padding-medium'>
-              <code dangerouslySetInnerHTML={this.markupCode()} />
-            </pre>
+        <If condition={Boolean(this.props.code)}>
+          <div className='column medium-0 large-6 xlarge-5 padding-reset' ref={this.setHeightOnce}>
+            <div className='code-bar'>
+              <pre className='padding-medium'>
+                <code dangerouslySetInnerHTML={this.markupCode()} />
+              </pre>
+            </div>
           </div>
-        </div>
+        </If>
       </div>
     );
   }


### PR DESCRIPTION
## Overview
On large screens, the code section should take up less space and the content section should take up more. Right now, they're each equal. This PR makes their respective widths more suitable for any given screen size.

This only applies at small & tablet-sized browser widths. The desktop layout remains as it was before.

**Before:**
> The code section is too narrow to be useful on a small screen

![Before: narrow layout](https://user-images.githubusercontent.com/2024396/28801381-3f10479a-761f-11e7-911d-4b3f416b6fb2.png)

**After:**
> Stacked layout improves overall viewing experience

![After: narrow layout](https://user-images.githubusercontent.com/2024396/28801376-39ee6cd8-761f-11e7-8eaa-c185c0485206.png)
