### PR TITLE
Improved performance of carousel when there are many slides

### DIFF
--- a/components/Slide/Slide.jsx
+++ b/components/Slide/Slide.jsx
@@ -26,8 +26,9 @@ class Slide extends Component {
   render() {
     const { animationDuration, enter, enterDirection, exitDirection, isMobile, zIndex } = this.props.dynamicProps;
     const { buttonClass, title, subtitle, description, img, mobileImg, links, isWide } = this.props;
+    const visibility = zIndex === '-1' ? 'hidden' : 'visible';
     return (
-      <div className={`slide ${exitDirection} ${enter ? `ENTER_${enterDirection}` : ''}`} style={{ zIndex, animationDuration: `${animationDuration}ms` }}>
+      <div className={`slide ${exitDirection} ${enter ? `ENTER_${enterDirection}` : ''}`} style={{ animationDuration: `${animationDuration}ms`, visibility, zIndex }}>
         <div className={isMobile ? 'slide-bg slide-bg--mobile' : 'slide-bg' }>
           <div className={isWide ? 'slide-layout-wide' : 'slide-layout-container'}>
             <img className='slide-bg-img' src={isMobile ? mobileImg : img} alt={title} style={{ height: `${this.getImgHeight()}px` }} />

--- a/demo/src/sections/Carousels.jsx
+++ b/demo/src/sections/Carousels.jsx
@@ -104,6 +104,21 @@ const Slide5 = {
   id: 's5',
 };
 
+const loadTestSlides = Array(50).fill(true).map((x, i) => ({
+  Slide: props => (
+    <Slide
+      dynamicProps={props}
+      title={`Slide ${i}`}
+      subtitle='(Load test slide)'
+      description={lorem}
+      img={`http://lorempizza.com/1600/900/${i}`}
+      mobileImg={`http://lorempizza.com/1600/900/${i}`}
+      isWide={true}
+      links={{ item: '#' }}
+    />
+  ),
+  id: `slide${i}`,
+}));
 
 const CarouselDemo = () => (
   <div>
@@ -112,6 +127,9 @@ const CarouselDemo = () => (
     <br />
     <Subtitle>Multi-Slide Carousel</Subtitle>
     <Carousel slides={[ Slide1, Slide2, Slide3, Slide4, Slide5 ]} />
+    <br />
+    <Subtitle>Carousel Performance Load Test (50 Slides)</Subtitle>
+    <Carousel slides={loadTestSlides} />
   </div>
 );
 

--- a/demo/src/sections/Carousels.jsx
+++ b/demo/src/sections/Carousels.jsx
@@ -111,7 +111,7 @@ const loadTestSlides = Array(50).fill(true).map((x, i) => ({
       title={`Slide ${i}`}
       subtitle='(Load test slide)'
       description={lorem}
-      img={`http://lorempizza.com/1600/900/${i}`}
+      img={`http://lorempizza.com/1600/600/${i}`}
       mobileImg={`http://lorempizza.com/1600/900/${i}`}
       isWide={true}
       links={{ item: '#' }}

--- a/dist/carousel.css
+++ b/dist/carousel.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.4
+  Quartz-react version: 0.0.5
   Current file hash: 064240763173612ae21da9cf52848651
 */
 

--- a/dist/demo.css
+++ b/dist/demo.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.4
+  Quartz-react version: 0.0.5
   Current file hash: 1b9a1a73053e8c1ff0f9fe7349e22367
 */
 

--- a/dist/quartz-react.js
+++ b/dist/quartz-react.js
@@ -1175,8 +1175,9 @@ var Slide$1 = (function (Component$$1) {
     var mobileImg = ref$1.mobileImg;
     var links = ref$1.links;
     var isWide = ref$1.isWide;
+    var visibility = zIndex === '-1' ? 'hidden' : 'visible';
     return (
-      React__default.createElement( 'div', { className: ("slide " + exitDirection + " " + (enter ? ("ENTER_" + enterDirection) : '')), style: { zIndex: zIndex, animationDuration: (animationDuration + "ms") } },
+      React__default.createElement( 'div', { className: ("slide " + exitDirection + " " + (enter ? ("ENTER_" + enterDirection) : '')), style: { animationDuration: (animationDuration + "ms"), visibility: visibility, zIndex: zIndex } },
         React__default.createElement( 'div', { className: isMobile ? 'slide-bg slide-bg--mobile' : 'slide-bg' },
           React__default.createElement( 'div', { className: isWide ? 'slide-layout-wide' : 'slide-layout-container' },
             React__default.createElement( 'img', { className: 'slide-bg-img', src: isMobile ? mobileImg : img, alt: title, style: { height: ((this.getImgHeight()) + "px") } })

--- a/dist/sidebar.css
+++ b/dist/sidebar.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.4
+  Quartz-react version: 0.0.5
   Current file hash: 84597099e5e0f8f7fecadfd205ab51f2
 */
 

--- a/dist/slide.css
+++ b/dist/slide.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.4
+  Quartz-react version: 0.0.5
   Current file hash: 23e145e1c6d946775b1f196d0c6ba97e
 */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vhx/quartz-react",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React Components for VHX Quartz",
   "main": "dist/quartz-react.js",
   "scripts": {


### PR DESCRIPTION
This PR addresses performance issues with the Carousel component.

By having all slides "visible" at the same time (just hidden because of their negative z-index), the browser had to perform a lot of unnecessary calculations. This made the carousel unusable for a high number of elements. It also caused a single-frame flickering issue at large screen sizes.

I am not sure if this fixes the flickering issue completely, but in my tests it has. 

I have also added a client-side load test to the demo with 50 slides. Prior to this fix I couldn't even scroll the page with that many slides.