### PR TITLE
Improve carousel performance more (VHX-1127)

### DIFF
--- a/components/Slide/Slide.jsx
+++ b/components/Slide/Slide.jsx
@@ -26,9 +26,9 @@ class Slide extends Component {
   render() {
     const { animationDuration, enter, enterDirection, exitDirection, isMobile, zIndex } = this.props.dynamicProps;
     const { buttonClass, title, subtitle, description, img, mobileImg, links, isWide } = this.props;
-    const visibility = zIndex === '-1' ? 'hidden' : 'visible';
+    const display = zIndex === '-1' ? 'none' : 'block';
     return (
-      <div className={`slide ${exitDirection} ${enter ? `ENTER_${enterDirection}` : ''}`} style={{ animationDuration: `${animationDuration}ms`, visibility, zIndex }}>
+      <div className={`slide ${exitDirection} ${enter ? `ENTER_${enterDirection}` : ''}`} style={{ animationDuration: `${animationDuration}ms`, display, zIndex }}>
         <div className={isMobile ? 'slide-bg slide-bg--mobile' : 'slide-bg' }>
           <div className={isWide ? 'slide-layout-wide' : 'slide-layout-container'}>
             <img className='slide-bg-img' src={isMobile ? mobileImg : img} alt={title} style={{ height: `${this.getImgHeight()}px` }} />

--- a/dist/carousel.css
+++ b/dist/carousel.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.5
+  Quartz-react version: 0.0.6
   Current file hash: 064240763173612ae21da9cf52848651
 */
 

--- a/dist/demo.css
+++ b/dist/demo.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.5
+  Quartz-react version: 0.0.6
   Current file hash: 1b9a1a73053e8c1ff0f9fe7349e22367
 */
 

--- a/dist/quartz-react.js
+++ b/dist/quartz-react.js
@@ -1175,9 +1175,9 @@ var Slide$1 = (function (Component$$1) {
     var mobileImg = ref$1.mobileImg;
     var links = ref$1.links;
     var isWide = ref$1.isWide;
-    var visibility = zIndex === '-1' ? 'hidden' : 'visible';
+    var display = zIndex === '-1' ? 'none' : 'block';
     return (
-      React__default.createElement( 'div', { className: ("slide " + exitDirection + " " + (enter ? ("ENTER_" + enterDirection) : '')), style: { animationDuration: (animationDuration + "ms"), visibility: visibility, zIndex: zIndex } },
+      React__default.createElement( 'div', { className: ("slide " + exitDirection + " " + (enter ? ("ENTER_" + enterDirection) : '')), style: { animationDuration: (animationDuration + "ms"), display: display, zIndex: zIndex } },
         React__default.createElement( 'div', { className: isMobile ? 'slide-bg slide-bg--mobile' : 'slide-bg' },
           React__default.createElement( 'div', { className: isWide ? 'slide-layout-wide' : 'slide-layout-container' },
             React__default.createElement( 'img', { className: 'slide-bg-img', src: isMobile ? mobileImg : img, alt: title, style: { height: ((this.getImgHeight()) + "px") } })

--- a/dist/sidebar.css
+++ b/dist/sidebar.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.5
+  Quartz-react version: 0.0.6
   Current file hash: 84597099e5e0f8f7fecadfd205ab51f2
 */
 

--- a/dist/slide.css
+++ b/dist/slide.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.0.5
+  Quartz-react version: 0.0.6
   Current file hash: 23e145e1c6d946775b1f196d0c6ba97e
 */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vhx/quartz-react",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "React Components for VHX Quartz",
   "main": "dist/quartz-react.js",
   "scripts": {


### PR DESCRIPTION
Using `display` instead of `visibility` helped improve rendering performance of the slides in the Carousel component.

Fixes https://vimean.atlassian.net/browse/VHX-1127 and improves upon #43 