### PR TITLE
Pagination Component

### DIFF
--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -20,7 +20,7 @@ class Pagination extends Component {
   link(i) {
     const { currentIndex, onChange } = this.props;
     return (
-      <span className={`text--bold padding-vert-xsmall padding-horz-small radius ${currentIndex === i ? 'bg-gray-5 text--white pagination-default' : 'pagination-pointer'}`} onClick={() => onChange(i)} key={`link-${i}`}>
+      <span className={`text--bold padding-vert-xsmall padding-horz-small radius ${currentIndex === i ? 'bg-gray-5 text--white pagination-default' : 'pagination-pointer pagination-link'}`} onClick={() => onChange(i)} key={`link-${i}`}>
         {i + 1}
       </span>
     );
@@ -31,7 +31,6 @@ class Pagination extends Component {
     const { link } = this;
     const truncateBefore = currentIndex > 3 && length > MAX_VISIBLE_LINKS;
     const truncateAfter = currentIndex < length - 4 && length > MAX_VISIBLE_LINKS;
-    console.log({ currentIndex, truncateBefore, truncateAfter });
     const links = [];
     if (truncateBefore) links.push(<Separator key='sep-0' />);
     if (truncateBefore && truncateAfter) {
@@ -59,15 +58,16 @@ class Pagination extends Component {
   }
 
   render() {
-    const { prevButton, nextButton, link } = this;
+    const { prevButton, nextButton, link, links } = this;
     const { currentIndex, onChange, length } = this.props;
+    // NOTE: we hide the text rather than removing the "Previous"/"Next" links altogether so that the layout doesn't re-center when those links disappear
     return (
       <nav className='text-center'>
-        <span className={`text--bold padding-small ${currentIndex === 0 ? 'pagination-default text--white pagination-invisible' : 'pagination-pointer text--teal'}`} onClick={() => onChange(currentIndex - 1) }>← Previous</span>
+        <span className={`text--bold padding-small ${currentIndex === 0 ? 'pagination-default pagination-invisible' : 'pagination-pointer text--teal'}`} onClick={() => onChange(currentIndex - 1) }>← Previous</span>
         { link(0) /* hard-code first pagination link */ }
-        { this.links() /* dynamically generate range between first and last link */ }
+        { links() /* dynamically generate range between first and last link */ }
         { link(length - 1)/* hard-code last pagination link */ }
-        <span className={`text--bold padding-small ${currentIndex === length - 1 ? 'pagination-default text--white pagination-invisible' : 'pagination-pointer text--teal' }`} onClick={() => onChange(currentIndex + 1)}>Next →</span>
+        <span className={`text--bold padding-small ${currentIndex === length - 1 ? 'pagination-default pagination-invisible' : 'pagination-pointer text--teal' }`} onClick={() => onChange(currentIndex + 1)}>Next →</span>
       </nav>
     );
   }

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { If } from '../util';
 
 const MAX_VISIBLE_LINKS = 7;
 
@@ -37,20 +35,17 @@ class Pagination extends Component {
       links.push(link(currentIndex - 1));
       links.push(link(currentIndex));
       links.push(link(currentIndex + 1));
-    }
-    else if (truncateBefore) { 
+    } else if (truncateBefore) { 
       links.push(link(length - 5));
       links.push(link(length - 4));
       links.push(link(length - 3));
       links.push(link(length - 2));
-    }
-    else if (truncateAfter) {
+    } else if (truncateAfter) {
       links.push(link(1));
       links.push(link(2));
       links.push(link(3));
       links.push(link(4));
-    }
-    else if (length > 1) {
+    } else if (length > 1) {
       for (let i = 1; i < length - 1; i++) links.push(link(i));
     }
     if (truncateAfter) links.push(<Separator key={`sep-${currentIndex + 2}`} />);
@@ -58,9 +53,9 @@ class Pagination extends Component {
   }
 
   render() {
-    const { prevButton, nextButton, link, links } = this;
+    const { link, links } = this;
     const { currentIndex, onChange, length } = this.props;
-    
+
     if (length === 0) return <nav />;
     if (length === 1) return <nav className='text-center'>{link(0)}</nav>;
 
@@ -71,7 +66,7 @@ class Pagination extends Component {
         { link(0) /* hard-code first pagination link */ }
         { links() /* dynamically generate range between first and last link */ }
         { link(length - 1)/* hard-code last pagination link */ }
-        <span className={`pagination-link text--bold padding-small text--teal ${currentIndex === length - 1 ? 'invisible' : '' }`} onClick={() => onChange(currentIndex + 1)}>Next →</span>
+        <span className={`pagination-link text--bold padding-small text--teal ${currentIndex === length - 1 ? 'invisible' : ''}`} onClick={() => onChange(currentIndex + 1)}>Next →</span>
       </nav>
     );
   }

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -35,7 +35,7 @@ class Pagination extends Component {
       links.push(link(currentIndex - 1));
       links.push(link(currentIndex));
       links.push(link(currentIndex + 1));
-    } else if (truncateBefore) { 
+    } else if (truncateBefore) {
       links.push(link(length - 5));
       links.push(link(length - 4));
       links.push(link(length - 3));

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { If } from '../util';
+
+const MAX_VISIBLE_LINKS = 7;
+
+const Separator = () => (
+  <span className='padding-small text--bold pagination-default'>...</span>
+);
+
+
+class Pagination extends Component {
+  constructor() {
+    super();
+    this.link = this.link.bind(this);
+    this.links = this.links.bind(this);
+  }
+
+  link(i) {
+    const { currentIndex, onChange } = this.props;
+    return (
+      <span className={`text--bold padding-vert-xsmall padding-horz-small radius ${currentIndex === i ? 'bg-gray-5 text--white pagination-default' : 'pagination-pointer'}`} onClick={() => onChange(i)} key={`link-${i}`}>
+        {i + 1}
+      </span>
+    );
+  }
+
+  links() {
+    const { currentIndex, length } = this.props;
+    const { link } = this;
+    const truncateBefore = currentIndex > 3 && length > MAX_VISIBLE_LINKS;
+    const truncateAfter = currentIndex < length - 4 && length > MAX_VISIBLE_LINKS;
+    console.log({ currentIndex, truncateBefore, truncateAfter });
+    const links = [];
+    if (truncateBefore) links.push(<Separator key='sep-0' />);
+    if (truncateBefore && truncateAfter) {
+      links.push(link(currentIndex - 1));
+      links.push(link(currentIndex));
+      links.push(link(currentIndex + 1));
+    }
+    else if (truncateBefore) { 
+      links.push(link(length - 5));
+      links.push(link(length - 4));
+      links.push(link(length - 3));
+      links.push(link(length - 2));
+    }
+    else if (truncateAfter) {
+      links.push(link(1));
+      links.push(link(2));
+      links.push(link(3));
+      links.push(link(4));
+    }
+    else if (length > 1) {
+      for (let i = 1; i < length - 1; i++) links.push(link(i));
+    }
+    if (truncateAfter) links.push(<Separator key={`sep-${currentIndex + 2}`} />);
+    return links;
+  }
+
+  render() {
+    const { prevButton, nextButton, link } = this;
+    const { currentIndex, onChange, length } = this.props;
+    return (
+      <nav className='text-center'>
+        <span className={`text--bold padding-small ${currentIndex === 0 ? 'pagination-default text--white pagination-invisible' : 'pagination-pointer text--teal'}`} onClick={() => onChange(currentIndex - 1) }>← Previous</span>
+        { link(0) /* hard-code first pagination link */ }
+        { this.links() /* dynamically generate range between first and last link */ }
+        { link(length - 1)/* hard-code last pagination link */ }
+        <span className={`text--bold padding-small ${currentIndex === length - 1 ? 'pagination-default text--white pagination-invisible' : 'pagination-pointer text--teal' }`} onClick={() => onChange(currentIndex + 1)}>Next →</span>
+      </nav>
+    );
+  }
+}
+
+
+Pagination.propTypes = {
+  currentIndex: PropTypes.number,
+  length: PropTypes.number.isRequired,
+  onChange: PropTypes.func,
+};
+
+Pagination.defaultProps = {
+  currentIndex: 0,
+  onChange: () => {},
+};
+
+export default Pagination;

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -60,6 +60,10 @@ class Pagination extends Component {
   render() {
     const { prevButton, nextButton, link, links } = this;
     const { currentIndex, onChange, length } = this.props;
+    
+    if (length === 0) return <nav />;
+    if (length === 1) return <nav className='text-center'>{link(0)}</nav>;
+
     // NOTE: we hide the text rather than removing the "Previous"/"Next" links altogether so that the layout doesn't re-center when those links disappear
     return (
       <nav className='text-center'>

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -59,7 +59,7 @@ class Pagination extends Component {
     if (length === 0) return <nav />;
     if (length === 1) return <nav className='text-center'>{link(0)}</nav>;
 
-    // NOTE: we hide the text rather than removing the "Previous"/"Next" links altogether so that the layout doesn't re-center when those links disappear
+    // NOTE: we toggle the visibility of the "Previous"/"Next" links rather than removing those links altogether so that the layout doesn't re-center when those links disappear
     return (
       <nav className='text-center'>
         <span className={`pagination-link text--bold padding-small text--teal ${currentIndex === 0 ? 'invisible' : ''}`} onClick={() => onChange(currentIndex - 1) }>← Previous</span>

--- a/components/Pagination/Pagination.jsx
+++ b/components/Pagination/Pagination.jsx
@@ -20,7 +20,7 @@ class Pagination extends Component {
   link(i) {
     const { currentIndex, onChange } = this.props;
     return (
-      <span className={`text--bold padding-vert-xsmall padding-horz-small radius ${currentIndex === i ? 'bg-gray-5 text--white pagination-default' : 'pagination-pointer pagination-link'}`} onClick={() => onChange(i)} key={`link-${i}`}>
+      <span className={`pagination-button text--bold padding-vert-xsmall padding-horz-small radius ${currentIndex === i ? 'active bg-gray-5 text--white' : ''}`} onClick={() => onChange(i)} key={`link-${i}`}>
         {i + 1}
       </span>
     );
@@ -67,11 +67,11 @@ class Pagination extends Component {
     // NOTE: we hide the text rather than removing the "Previous"/"Next" links altogether so that the layout doesn't re-center when those links disappear
     return (
       <nav className='text-center'>
-        <span className={`text--bold padding-small ${currentIndex === 0 ? 'pagination-default pagination-invisible' : 'pagination-pointer text--teal'}`} onClick={() => onChange(currentIndex - 1) }>← Previous</span>
+        <span className={`pagination-link text--bold padding-small text--teal ${currentIndex === 0 ? 'invisible' : ''}`} onClick={() => onChange(currentIndex - 1) }>← Previous</span>
         { link(0) /* hard-code first pagination link */ }
         { links() /* dynamically generate range between first and last link */ }
         { link(length - 1)/* hard-code last pagination link */ }
-        <span className={`text--bold padding-small ${currentIndex === length - 1 ? 'pagination-default pagination-invisible' : 'pagination-pointer text--teal' }`} onClick={() => onChange(currentIndex + 1)}>Next →</span>
+        <span className={`pagination-link text--bold padding-small text--teal ${currentIndex === length - 1 ? 'invisible' : '' }`} onClick={() => onChange(currentIndex + 1)}>Next →</span>
       </nav>
     );
   }

--- a/components/Pagination/Pagination.test.jsx
+++ b/components/Pagination/Pagination.test.jsx
@@ -1,14 +1,141 @@
 import jsdom from 'mocha-jsdom';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, render, shallow } from 'enzyme';
 import { expect } from 'chai';
-import Text from './Text.jsx';
+import Pagination from './Pagination.jsx';
 
-describe('Text', () => {
+describe('Pagination', () => {
   jsdom();
 
   it('Renders', () => {
-    const wrapper = shallow(<Text>foo</Text>);
+    const wrapper = shallow(<Pagination length={1} />);
     expect(wrapper.exists()).to.equal(true);
+  });
+
+  it('Handles length: 0', () => {
+    const wrapper = render(<Pagination length={0} />);
+    expect(wrapper.text()).to.equal('');
+  });
+
+  it('[1]', () => {
+    const wrapper = render(<Pagination length={1} />);
+    expect(wrapper.text()).to.include('1');
+  });
+
+  it('[1] 2 ->', () => {
+    const wrapper = render(<Pagination length={2} />);
+    expect(wrapper.text()).to.include('12');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('1');
+    expect(wrapper.find('.pagination-link.invisible').text()).to.include('Previous');
+  });
+
+  it('<- 1 [2]', () => {
+    const wrapper = render(<Pagination length={2} currentIndex={1} />);
+    expect(wrapper.text()).to.include('12');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('2');
+    expect(wrapper.find('.pagination-link.invisible').text()).to.include('Next');
+  });
+
+  it('[1] 2 3 ->', () => {
+    const wrapper = render(<Pagination length={3} />);
+    expect(wrapper.text()).to.include('123');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('1');
+    expect(wrapper.find('.pagination-link.invisible').text()).to.include('Previous');
+  });
+
+  it('<- 1 [2] 3 ->', () => {
+    const wrapper = render(<Pagination length={3} currentIndex={1} />);
+    expect(wrapper.text()).to.include('123');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('2');
+    expect(wrapper.html()).to.not.include('.pagination-link.invisible');
+  });
+
+  it('<- 1 2 [3]', () => {
+    const wrapper = render(<Pagination length={3} currentIndex={2} />);
+    expect(wrapper.text()).to.include('123');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('3');
+    expect(wrapper.find('.pagination-link.invisible').text()).to.include('Next');
+  });
+
+  it('[1] 2 3 4 5 6 7 ->', () => {
+    const wrapper = render(<Pagination length={7} />);
+    expect(wrapper.text()).to.include('1234567');
+    expect(wrapper.text()).to.not.include('...');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('1');
+    expect(wrapper.find('.pagination-link.invisible').text()).to.include('Previous');
+  });
+
+  it('[1] 2 3 4 5 ... 8 ->', () => {
+    const wrapper = render(<Pagination length={8} />);
+    expect(wrapper.text()).to.include('12345...8');
+    expect(wrapper.text()).to.not.include('6');
+    expect(wrapper.text()).to.not.include('7');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('1');
+    expect(wrapper.find('.pagination-link.invisible').text()).to.include('Previous');
+  });
+
+  it('<- 1 [2] 3 4 5 ... 8 ->', () => {
+    const wrapper = render(<Pagination length={8} currentIndex={1} />);
+    expect(wrapper.text()).to.include('12345...8');
+    expect(wrapper.text()).to.not.include('6');
+    expect(wrapper.text()).to.not.include('7');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('2');
+    expect(wrapper.html()).to.not.include('invisible');
+  });
+
+  it('<- 1 ... 4 [5] 6 7 8 ->', () => {
+    const wrapper = render(<Pagination length={8} currentIndex={4} />);
+    expect(wrapper.text()).to.include('1...45678');
+    expect(wrapper.text()).to.not.include('2');
+    expect(wrapper.text()).to.not.include('3');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('5');
+    expect(wrapper.html()).to.not.include('invisible');
+  });
+
+  it('<- 1 ... 4 [5] 6 ... 9 ->', () => {
+    const wrapper = render(<Pagination length={9} currentIndex={4} />);
+    expect(wrapper.text()).to.include('1...456...9');
+    expect(wrapper.text()).to.not.include('2');
+    expect(wrapper.text()).to.not.include('3');
+    expect(wrapper.text()).to.not.include('7');
+    expect(wrapper.text()).to.not.include('8');
+    expect(wrapper.find('.pagination-button.active').text()).to.equal('5');
+    expect(wrapper.html()).to.not.include('invisible');
+  });
+
+  it('Handles "Previous" callback', () => {
+    let callCount = 0;
+    const cb = (newIndex) => {
+      callCount++;
+      expect(newIndex).to.equal(3);
+    };
+
+    const wrapper = mount(<Pagination length={9} currentIndex={4} onChange={cb} />);
+    wrapper.find('.pagination-link').first().simulate('click');
+    expect(callCount).to.equal(1);
+  });
+
+  it('Handles "Next" callback', () => {
+    let callCount = 0;
+    const cb = (newIndex) => {
+      callCount++;
+      expect(newIndex).to.equal(5);
+    };
+
+    const wrapper = mount(<Pagination length={9} currentIndex={4} onChange={cb} />);
+    wrapper.find('.pagination-link').last().simulate('click');
+    expect(callCount).to.equal(1);
+  });
+
+  it('Handles button click callback', () => {
+    let callCount = 0;
+    const cb = (newIndex) => {
+      callCount++;
+      expect(newIndex).to.equal(0);
+    };
+
+    const wrapper = mount(<Pagination length={9} currentIndex={4} onChange={cb} />);
+    wrapper.find('.pagination-button').first().simulate('click');
+    expect(callCount).to.equal(1);
   });
 });

--- a/components/Pagination/Pagination.test.jsx
+++ b/components/Pagination/Pagination.test.jsx
@@ -1,0 +1,14 @@
+import jsdom from 'mocha-jsdom';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import Text from './Text.jsx';
+
+describe('Text', () => {
+  jsdom();
+
+  it('Renders', () => {
+    const wrapper = shallow(<Text>foo</Text>);
+    expect(wrapper.exists()).to.equal(true);
+  });
+});

--- a/components/Pagination/index.js
+++ b/components/Pagination/index.js
@@ -1,0 +1,3 @@
+import Pagination from './Pagination.jsx';
+
+export default Pagination;

--- a/demo/public/css/pagination.css
+++ b/demo/public/css/pagination.css
@@ -1,0 +1,14 @@
+.pagination-pointer {
+  cursor: pointer;
+  user-select: none;
+}
+
+.pagination-default {
+  cursor: default;
+  pointer-events: none;
+  user-select: none;
+}
+
+.pagination-invisible {
+  visibility: hidden;
+}

--- a/demo/public/css/pagination.css
+++ b/demo/public/css/pagination.css
@@ -12,3 +12,7 @@
 .pagination-invisible {
   visibility: hidden;
 }
+
+.pagination-link:hover {
+  background: #f0f2f4; /* gray-2 */
+}

--- a/demo/public/css/pagination.css
+++ b/demo/public/css/pagination.css
@@ -1,18 +1,27 @@
-.pagination-pointer {
+.pagination-link {
   cursor: pointer;
   user-select: none;
 }
 
-.pagination-default {
+.pagination-link.invisible {
+  visibility: hidden;
+}
+
+.pagination-button {
+  cursor: pointer;
+  user-select: none;
+}
+
+.pagination-button:hover {
+  background: #f0f2f4; /* gray-2 */
+}
+
+.pagination-button.active {
   cursor: default;
   pointer-events: none;
   user-select: none;
 }
 
-.pagination-invisible {
-  visibility: hidden;
-}
-
-.pagination-link:hover {
-  background: #f0f2f4; /* gray-2 */
+.pagination-button.active:hover {
+  background: #869AA5; /* gray-5 */
 }

--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="http://quartz.vhx.tv/components.css">
   <link rel="stylesheet" href="/css/demo.css">
   <link rel="stylesheet" href="/css/carousel.css">
+  <link rel="stylesheet" href="/css/pagination.css">
   <link rel="stylesheet" href="/css/slide.css">
   <link rel="stylesheet" href="/css/sidebar.css">
   <script>

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -11,6 +11,7 @@ import Checkboxes from './sections/Checkboxes.jsx';
 import Icons from './sections/Icons.jsx';
 import Inputs from './sections/Inputs.jsx';
 import Modals from './sections/Modals.jsx';
+import Pagination from './sections/Pagination.jsx';
 import Radios from './sections/Radios.jsx';
 import Selects from './sections/Selects.jsx';
 import Sidebars from './sections/Sidebars.jsx';
@@ -25,6 +26,7 @@ const sections = {
   Icons,
   Inputs,
   Modals,
+  Pagination,
   'Radio Groups': Radios,
   Selects,
   Sidebars,

--- a/demo/src/sections/Pagination.jsx
+++ b/demo/src/sections/Pagination.jsx
@@ -30,10 +30,10 @@ class StatefulPagination extends Component {
 const PaginatorDemo = () => (
   <div>
     {
-      Array(9).fill(true).map((_, i) => (
+      [1, 2, 7, 8, 9].map((i) => (
         <div key={i}>
-          <Subtitle>Page count: {i + 1}</Subtitle>
-          <StatefulPagination length={i + 1} />
+          <Subtitle>Demo page count: {i}</Subtitle>
+          <StatefulPagination length={i} />
         </div>
       ))
     }

--- a/demo/src/sections/Pagination.jsx
+++ b/demo/src/sections/Pagination.jsx
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Pagination } from '../../../index.js';
+import {
+  Block,
+  DemoRow,
+  Subtitle,
+  Title,
+} from '../ui';
+
+class StatefulPagination extends Component {
+  constructor() {
+    super();
+    this.state = { selectedIndex: 0 };
+    this.updateIndex = this.updateIndex.bind(this);
+  }
+
+  updateIndex(selectedIndex) {
+    this.setState({ selectedIndex });
+  }
+
+  render() {
+    return (
+      <Pagination currentIndex={this.state.selectedIndex} length={this.props.length} onChange={this.updateIndex} />
+    );
+  }
+}
+
+const PaginatorDemo = () => (
+  <div>
+    {
+      Array(9).fill(true).map((_, i) => (
+        <div key={i}>
+          <Subtitle>Page count: {i + 1}</Subtitle>
+          <StatefulPagination length={i + 1} />
+        </div>
+      ))
+    }
+  </div>
+);
+
+const paginatorCode = `
+(test)
+`;
+
+
+// Main exported demo
+// -----------------------------------------
+
+const Paginators = ({ title }) => (
+  <div>
+    <DemoRow><Title>{title}</Title></DemoRow>
+    <DemoRow code={paginatorCode}><PaginatorDemo /></DemoRow>
+  </div>
+);
+
+Paginators.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default Paginators;

--- a/demo/src/sections/Pagination.jsx
+++ b/demo/src/sections/Pagination.jsx
@@ -4,6 +4,7 @@ import { Pagination } from '../../../index.js';
 import {
   Block,
   DemoRow,
+  Details,
   Subtitle,
   Title,
 } from '../ui';
@@ -40,7 +41,26 @@ const PaginatorDemo = () => (
 );
 
 const paginatorCode = `
-(test)
+// A stateful implementation:
+class StatefulPagination extends Component {
+  constructor() {
+    super();
+    this.state = { selectedIndex: 0 };
+    this.updateIndex = this.updateIndex.bind(this);
+  }
+
+  updateIndex(selectedIndex) {
+    this.setState({ selectedIndex });
+  }
+
+  render() {
+    const i = this.state.selectedIndex;
+    const length = this.props.length;
+    return (
+      <Pagination currentIndex={i} length={length} onChange={this.updateIndex} />
+    );
+  }
+}
 `;
 
 
@@ -49,8 +69,16 @@ const paginatorCode = `
 
 const Paginators = ({ title }) => (
   <div>
-    <DemoRow><Title>{title}</Title></DemoRow>
-    <DemoRow code={paginatorCode}><PaginatorDemo /></DemoRow>
+    <DemoRow>
+      <Title>{title}</Title>
+      <Details>
+        The <code>Pagination</code> component displays up to 7 page links and a
+        possible "Previous" or "Next" link when appropriate. It will also call
+        an <code>onChange</code> callback with the index of the new selected
+        link whenever one of the links (or "Previous"/"Next") is clicked.
+      </Details>
+    </DemoRow>
+   <DemoRow code={paginatorCode}><PaginatorDemo /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Pagination.jsx
+++ b/demo/src/sections/Pagination.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Pagination } from '../../../index.js';
 import {
-  Block,
   DemoRow,
   Details,
   Subtitle,
@@ -27,10 +26,14 @@ class StatefulPagination extends Component {
   }
 }
 
+StatefulPagination.propTypes = {
+  length: PropTypes.number.isRequired,
+};
+
 const PaginatorDemo = () => (
   <div>
     {
-      [1, 2, 7, 8, 9].map((i) => (
+      [1, 2, 7, 8, 9].map(i => (
         <div key={i}>
           <Subtitle>Demo page count: {i}</Subtitle>
           <StatefulPagination length={i} />
@@ -78,7 +81,7 @@ const Paginators = ({ title }) => (
         link whenever one of the links (or "Previous"/"Next") is clicked.
       </Details>
     </DemoRow>
-   <DemoRow code={paginatorCode}><PaginatorDemo /></DemoRow>
+    <DemoRow code={paginatorCode}><PaginatorDemo /></DemoRow>
   </div>
 );
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ export { default as Header } from './components/Header';
 export { default as Icon } from './components/Icon';
 export { default as Input } from './components/Input';
 export { default as Modal } from './components/Modal';
+export { default as Pagination } from './components/Pagination';
 export { default as RadioGroup } from './components/RadioGroup';
 export { default as Sidebar } from './components/Sidebar';
 export { default as Slide } from './components/Slide';


### PR DESCRIPTION
## Overview

This PR adds a Pagination component. Usage is as follows:

```jsx
<Pagination
  length={this.state.pageCount}
  currentIndex={this.state.currentPage}
  onChange={(currentPage) => this.setState({ currentPage })}
/>
```

In context, that would be something like this:

```jsx
import React, { Component } from 'react';
import { Pagination } from '@vhx/quartz-react';

class MyPage extends Component {
  constructor() {
    super();
    this.state = {
      currentPage: 0,
      pageCount: 0,
    };
  }
  componentWillMount() {
    // This would make a request to get the total number of rows or pages
  }
  fetchPage(nextPage) {
    // This function would also make an ajax request to get the new page's contents
    this.setState({ currentPage: nextPage });
  }
  render() {
    return (
      <div>
        <table>
          { /* video/collection rows would go here... */ }
        </table>
        <Pagination
          length={this.state.pageCount}
          currentIndex={this.state.currentPage}
          onChange={this.fetchPage}
        />
      </div>
    );
  }
}
```

The most important thing to understand here is the component's `onChange` handler. Whenever "Next", "Previous", or any of the numbers are clicked, that callback will be called with the index of the *new* active page.

## Preview
![2017-08-08-155017_2880x1800_scrot](https://user-images.githubusercontent.com/2024396/29092502-84bbe502-7c54-11e7-8b4e-1649e3b3ecb6.png)

![2017-08-08-162617_2880x1800_scrot](https://user-images.githubusercontent.com/2024396/29092952-15f0abb0-7c56-11e7-88d3-c3a25853d992.png)

