### PR TITLE
Fix Linter (and resolve lint issues)

### DIFF
--- a/components/Avatar/Avatar.jsx
+++ b/components/Avatar/Avatar.jsx
@@ -6,22 +6,24 @@ import PropTypes from 'prop-types';
 
 const Avatar = props => (
   <span className={`avatar color-teal avatar--${props.size}`}>
-    <span className="avatar-user user-avatar" 
-    style={{
-      'backgroundImage': `url('${props.image}')`    
-    }} />
-    
+    <span
+      className='avatar-user user-avatar'
+      style={{
+        backgroundImage: `url('${props.image}')`,
+      }}
+    />
+
   </span>
 );
 
 Avatar.propTypes = {
-  size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge']),
-  image: PropTypes.string
+  size: PropTypes.oneOf([ 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge' ]),
+  image: PropTypes.string,
 };
 
 Avatar.defaultProps = {
   size: 'medium',
-  image: ''
+  image: '',
 };
 
 export default Avatar;

--- a/components/Carousel/Carousel.jsx
+++ b/components/Carousel/Carousel.jsx
@@ -25,6 +25,11 @@ function containValue(max, min, value) {
   return value;
 }
 
+function getZIndex(topSlideIndex, bgSlideIndex, currentIndex) {
+  if (currentIndex === topSlideIndex) return '1';
+  if (currentIndex === bgSlideIndex) return '0';
+  return '-1';
+}
 
 class Carousel extends Component {
   constructor(props) {
@@ -143,7 +148,7 @@ class Carousel extends Component {
                 height={height}
                 isMobile={isMobile}
                 width={width}
-                zIndex={topSlideIndex === i ? '1' : bgSlideIndex === i ? '0' : '-1'}
+                zIndex={getZIndex(topSlideIndex, bgSlideIndex, i)}
               />
             ))
           }

--- a/components/Modal/Modal.jsx
+++ b/components/Modal/Modal.jsx
@@ -36,7 +36,7 @@ class Modal extends Component {
 
   componentWillMount() {
     if (modalsInitialized !== 0) {
-      console.error('<Modal /> must be mounted only once');
+      console.error('<Modal /> must be mounted only once'); // eslint-disable-line no-console
     }
     modalsInitialized++;
     window.addEventListener('keyup', handleEscapeKey);

--- a/components/Select/Select.test.jsx
+++ b/components/Select/Select.test.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+
 import jsdom from 'mocha-jsdom';
 import React from 'react';
 import { mount, shallow } from 'enzyme';

--- a/components/Select/Trigger.jsx
+++ b/components/Select/Trigger.jsx
@@ -14,7 +14,17 @@ function getTriggerClass({ color }) {
 }
 
 const Trigger = ({ color, isOpen, onOpenToggle, triggerLabel, triggerPlaceholder }) => (
-  <span className={getTriggerClass({ color })} onClick={() => onOpenToggle(!isOpen)}>{triggerLabel || triggerPlaceholder}</span>
+  <a
+    href='#'
+    role='button'
+    className={getTriggerClass({ color })}
+    onClick={(event) => {
+      event.preventDefault();
+      onOpenToggle(!isOpen);
+    }}
+  >
+    {triggerLabel || triggerPlaceholder}
+  </a>
 );
 
 Trigger.propTypes = {

--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -19,7 +19,7 @@ class Sidebar extends Component {
     const { isOpen, Contents } = this.props;
     return (
       <div className={`sidebar c-sidebar bg-white shadow--gray ${isOpen ? 'sidebar--open' : ''}`}>
-        <a className='c-sidebar--close icon-circle icon-x-navy icon--xsmall' onClick={() => sidebarModel.close()} />
+        <span className='c-sidebar--close icon-circle icon-x-navy icon--xsmall' style={{ cursor: 'pointer' }} onClick={() => sidebarModel.close()} />
         <div><Contents /></div>
       </div>
     );

--- a/demo/src/sections/Avatars.jsx
+++ b/demo/src/sections/Avatars.jsx
@@ -17,34 +17,34 @@ const AvatarDemo = () => (
   <div>
     <Subtitle>Headings</Subtitle>
     <Block inline><Avatar /></Block>
-    <Block inline><Avatar 
-      image="https://vhx.imgix.net/assets/1f843fdc-34da-4302-bd4f-06e5bd7ef2c3/IMG_7891.GIF"
-      size="xsmall" 
-      /></Block>
-      <Block inline><Avatar 
-        image="https://secure.gravatar.com/avatar/74b978ed4f10e05a6c2898c4f5516189.png"
-        size="small" 
-        /></Block>
-      <Block inline><Avatar 
-        image="https://secure.gravatar.com/avatar/74b978ed4f10e05a6c2898c4f5516189.png"
-        size="medium" 
-        /></Block>
-      <Block inline><Avatar 
-        image="https://secure.gravatar.com/avatar/460c13d4904dc7f889f00d2cd4c3e6e8.png"
-        size="large" 
-        /></Block>
-    <Block inline><Avatar 
-      image="https://vhx.imgix.net/assets/1f843fdc-34da-4302-bd4f-06e5bd7ef2c3/IMG_7891.GIF"
-      size="xlarge" 
-      /></Block>
+    <Block inline><Avatar
+      image='https://vhx.imgix.net/assets/1f843fdc-34da-4302-bd4f-06e5bd7ef2c3/IMG_7891.GIF'
+      size='xsmall'
+    /></Block>
+    <Block inline><Avatar
+      image='https://secure.gravatar.com/avatar/74b978ed4f10e05a6c2898c4f5516189.png'
+      size='small'
+    /></Block>
+    <Block inline><Avatar
+      image='https://secure.gravatar.com/avatar/74b978ed4f10e05a6c2898c4f5516189.png'
+      size='medium'
+    /></Block>
+    <Block inline><Avatar
+      image='https://secure.gravatar.com/avatar/460c13d4904dc7f889f00d2cd4c3e6e8.png'
+      size='large'
+    /></Block>
+    <Block inline><Avatar
+      image='https://vhx.imgix.net/assets/1f843fdc-34da-4302-bd4f-06e5bd7ef2c3/IMG_7891.GIF'
+      size='xlarge'
+    /></Block>
   </div>
 );
 
 const avatarCode = `
 <Avatar />
-<Avatar 
-image="https://[YOURIMAGEHERE].png"
-size="xlarge" 
+<Avatar
+  image='https://[YOURIMAGEHERE].png'
+  size='xlarge'
 />
 `;
 

--- a/demo/src/sections/Inputs.jsx
+++ b/demo/src/sections/Inputs.jsx
@@ -74,7 +74,7 @@ class StatefulInput extends Component {
   }
   render() {
     const { props, state } = this;
-    const handleInput = (event) => (
+    const handleInput = event => (
       this.setState({
         value: event.target.value,
       })

--- a/demo/src/sections/Selects.jsx
+++ b/demo/src/sections/Selects.jsx
@@ -174,7 +174,7 @@ class SelectMinimal extends Component {
     };
     this.handleChange = this.handleChange.bind(this);
   }
-  handleChange(selectedOptions, label /*, optionToggled, optionWillBeChecked */) {
+  handleChange(selectedOptions, label /* , optionToggled, optionWillBeChecked */) {
     this.setState({ selectedOptions, label });
   }
   render() {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node build/build-css.js && rollup -c build/rollup.config.js",
     "dev": "rollup -c build/rollup.demo-config.js --watch",
-    "lint": "eslint components/** demo/src/** build/** index.js",
+    "lint": "eslint components/**/** demo/src/** build/** index.js",
     "serve": "browser-sync start --server --serveStatic \"demo/public\" --files \"demo/public/js/bundle.js\" --no-open",
     "start": "npm-run-all --parallel dev serve",
     "test": "nyc --extension .jsx --reporter=html --reporter=text-summary mocha components/**/*.test.jsx --compilers js:babel-register",


### PR DESCRIPTION
## Overview

This PR solves a linting issue where none of the component files were being properly linted because eslint was not recursively checking files in the components directory. Changing `/components/**` to `/components/**/**` in `package.json` resolved this problem.

Once linting was fixed, there were many harmless stylistic errors that could be fixed by running `npm run lint -- --fix`. The majority of the changes in this PR are the result of running that.

Beyond that, there were a few manual changes:
1. Ignore the `no-console` rule wherever we actually want logs, such as when (incorrectly) mounting multiple modal components.
2. Add aria-roles and other jsx-a11y improvements.

There are still 7 remaining issues related to jsx-a11y that need to be improved, but might require a bit more time to resolve. This PR is meant to be a first step, and brings the lint errors/warnings down from 45 to 7.