### PR TITLE
Add <Header/> Demo

### DIFF
--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -8,6 +8,7 @@ import Avatars from './sections/Avatars.jsx';
 import Buttons from './sections/Buttons.jsx';
 import Carousels from './sections/Carousels.jsx';
 import Checkboxes from './sections/Checkboxes.jsx';
+import Headers from './sections/Headers.jsx';
 import Icons from './sections/Icons.jsx';
 import Inputs from './sections/Inputs.jsx';
 import Modals from './sections/Modals.jsx';
@@ -22,6 +23,7 @@ const sections = {
   Buttons,
   Carousels,
   Checkboxes,
+  Headers,
   Icons,
   Inputs,
   Modals,

--- a/demo/src/sections/Headers.jsx
+++ b/demo/src/sections/Headers.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Header } from '../../../index.js';
+import {
+  DemoRow,
+  Subtitle,
+  Title,
+} from '../ui';
+
+
+// Standard header
+// -----------------------------------------
+
+const DefaultDemo = () => (
+  <div>
+    <Subtitle>Default</Subtitle>
+    <Header icon='product' title='Hello World' Description='Optional description' />
+  </div>
+);
+
+const defaultDemoCode = `
+<Header
+  icon='product'
+  title='Hello World'
+  Description='Optional description'
+/>
+`;
+
+// Header with all options/props
+// -----------------------------------------
+
+const HeaderDescription = () => (
+  <div className='text--teal'>Foo</div>
+);
+
+const FullDemo = () => (
+  <div>
+    <Subtitle>Header with All Options</Subtitle>
+    <Header icon='product' title='Hello World' Description={HeaderDescription} border={false}>
+      <Button>Click me</Button>
+    </Header>
+  </div>
+);
+
+const fullDemoCode = `
+// \`Description\` can be a component or a string
+const HeaderDescription = () => (
+  <div className='text--teal'>Foo</div>
+);
+
+// Children can optionally be passed to the <Header>
+<Header icon='product' title='Hello World' Description={HeaderDescription} border={false}>
+  <Button>Click me</Button>
+</Header>
+`;
+
+
+// Main exported demo
+// -----------------------------------------
+
+const Headers = ({ title }) => (
+  <div>
+    <DemoRow><Title>{title}</Title></DemoRow>
+    <DemoRow code={defaultDemoCode}><DefaultDemo /></DemoRow>
+    <DemoRow code={fullDemoCode}><FullDemo /></DemoRow>
+  </div>
+);
+
+Headers.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default Headers;


### PR DESCRIPTION
## Overview
This PR adds a demo for the `<Header />` component. The component already existed but was missing a from the demo site.

<img width="1680" alt="screen shot 2017-08-10 at 2 33 43 pm" src="https://user-images.githubusercontent.com/2024396/29185992-18085dce-7dd9-11e7-8fd2-e1a30fb0b99f.png">
