### PR TITLE
Add PropTypeTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,48 @@ index.js                        # Every component that is exported in quartz-rea
     - [YourComponent].jsx
     - [YourComponent].test.jsx
 3. In the root level `index.js`, create a named export for your component.
-4. In `demo/src/sections/` create a file to demo your component (by convention, it should be `demo/src/sections/[YourComponent].jsx`). It should export a react component that makes use of the demo UI components (see below).
+4. In `demo/src/sections/` create a file to demo your component (by convention, it should be `demo/src/sections/[YourComponent].jsx`). It should export a react component that makes use of the demo UI components (see below). If your demo makes use of props, display them in a `<PropTypeTable />`.
 5. In `demo/src/index.jsx` import the demo you exported from the file in step 4, and add it to the `sections` object. This will include it in the sidebar navigation as well as render it to the page.
 6. Create a pull request and merge into master when ready. Then delete the branch.
 7. Run `npm version patch` (or `minor` or `major`, as appropriate), then run `npm run build`, then publish to npm.
 
+
+## Documenting Components
+
+In addition to the documentation in demo site, components should be self-documenting. Using `propTypes` and `defaultProps` help with this effort. A third, non-standard property called `propDescriptions` may additionally be used to document props.
+If any of these statics are defined on your component, use a `<PropTypeTable />`. For example:
+
+```jsx
+// in components/MyComponent/MyComponent.jsx
+// ---------------------------------------------
+const MyComponent = ({ title }) => <h1>{title.slice(0, 50)}</h1>;
+
+MyComponent.propTypes = {
+  title: PropTypes.string,
+};
+
+MyComponent.defaultProps = {
+  title: 'Hello World',
+};
+
+MyComponent.propDescriptions = {
+  title: 'A brief title, truncated at 50 characters'
+};
+
+// in demo/src/sections/MyComponent.jsx
+// ---------------------------------------------
+const MyComponentDemo = () => (
+  <div>
+    <DemoRow>
+      <Title>MyComponent</Title>
+      <Details>Some documentation for your component goes here...</Details>
+    </DemoRow>
+    <DemoRow>
+      <PropTypeTable component={MyComponent} />
+    </DemoRow>
+  </div>
+);
+```
 
 ## Demo UI Components
 

--- a/components/Avatar/Avatar.jsx
+++ b/components/Avatar/Avatar.jsx
@@ -16,14 +16,20 @@ const Avatar = props => (
   </span>
 );
 
+const sizes = [ 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge' ];
+
 Avatar.propTypes = {
-  size: PropTypes.oneOf([ 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge' ]),
+  size: PropTypes.oneOf(sizes),
   image: PropTypes.string,
 };
 
 Avatar.defaultProps = {
   size: 'medium',
   image: '',
+};
+
+Avatar.propDescriptions = {
+  size: `One of: ["${sizes.join('", "')}"]`,
 };
 
 export default Avatar;

--- a/components/Button/Button.jsx
+++ b/components/Button/Button.jsx
@@ -45,15 +45,18 @@ const Button = (props) => {
   );
 };
 
+const colors = [ 'gray', 'teal', 'white', 'red', 'purple', 'green', 'slate', 'black', 'yellow', 'transparent', 'twitter', 'facebook', 'tumblr', 'paypal', 'roku' ];
+const sizes = [ 'small', 'medium', 'large', 'half', 'fill' ];
+const typefaces = [ 'brandon', '' ];
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  color: PropTypes.oneOf([ 'gray', 'teal', 'white', 'red', 'purple', 'green', 'slate', 'black', 'yellow', 'transparent', 'twitter', 'facebook', 'tumblr', 'paypal', 'roku' ]),
+  color: PropTypes.oneOf(colors),
   processing: PropTypes.bool,
   onClick: PropTypes.func,
-  size: PropTypes.oneOf([ 'small', 'medium', 'large', 'half', 'fill' ]),
-  typeface: PropTypes.oneOf([ 'brandon', '' ]),
+  size: PropTypes.oneOf(sizes),
+  typeface: PropTypes.oneOf(typefaces),
 };
 
 Button.defaultProps = {
@@ -63,6 +66,13 @@ Button.defaultProps = {
   processing: false,
   size: 'medium',
   typeface: '',
+};
+
+Button.propDescriptions = {
+  color: `One of: ["${colors.join('", "')}"]`,
+  processing: 'Displays loading indicator',
+  size: `One of: ["${sizes.join('", "')}"]`,
+  typeface: `One of: ["${typefaces.join('", "')}"]`,
 };
 
 export default Button;

--- a/components/Carousel/Carousel.jsx
+++ b/components/Carousel/Carousel.jsx
@@ -189,12 +189,14 @@ Carousel.propTypes = {
   }).isRequired).isRequired,
 };
 
+const noop = () => {};
+
 Carousel.defaultProps = {
   animationDuration: 600, // ms
   aspectRatio: '16:6',
   maxHeight: 640, // px
   minHeight: 368, // px
-  onSlideChange: () => {},
+  onSlideChange: noop,
 };
 
 Carousel.propDescriptions = {

--- a/components/Carousel/Carousel.jsx
+++ b/components/Carousel/Carousel.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../Icon';
-import { If, getAspectRatioHeight } from '../util';
+import { If, getAspectRatioHeight, noop } from '../util';
 import { KEY_CODES } from '../util/constants';
 
 
@@ -188,8 +188,6 @@ Carousel.propTypes = {
     id: PropTypes.string.isRequired,
   }).isRequired).isRequired,
 };
-
-const noop = () => {};
 
 Carousel.defaultProps = {
   animationDuration: 600, // ms

--- a/components/Carousel/Carousel.jsx
+++ b/components/Carousel/Carousel.jsx
@@ -197,4 +197,10 @@ Carousel.defaultProps = {
   onSlideChange: () => {},
 };
 
+Carousel.propDescriptions = {
+  animationDuration: 'Milliseconds',
+  aspectRatio: 'String of two integers separated by ":"',
+  slides: 'Array of objects: { Slide: Component, id: String }',
+};
+
 export default Carousel;

--- a/components/Checkbox/Checkbox.jsx
+++ b/components/Checkbox/Checkbox.jsx
@@ -45,13 +45,16 @@ const Checkbox = props => (
 );
 
 
+const sizes = [ 'small', 'medium', 'large' ];
+const types = [ 'standard', 'toggle' ];
+
 Checkbox.propTypes = {
   checked: PropTypes.bool,
   label: PropTypes.string,
-  uniqueId: PropTypes.string.isRequired,
   onChange: PropTypes.func,
-  size: PropTypes.oneOf([ 'small', 'medium', 'large' ]),
-  type: PropTypes.oneOf([ 'standard', 'toggle' ]),
+  size: PropTypes.oneOf(sizes),
+  type: PropTypes.oneOf(types),
+  uniqueId: PropTypes.string.isRequired,
   value: PropTypes.string,
 };
 
@@ -62,6 +65,12 @@ Checkbox.defaultProps = {
   size: 'medium',
   type: 'standard',
   value: '',
+};
+
+Checkbox.propDescriptions = {
+  size: `One of: ["${sizes.join('", "')}"]`,
+  type: `One of: ["${types.join('", "')}"]`,
+  uniqueId: 'Must be globally unique--this sets the checkbox element\'s id attribute.',
 };
 
 export default Checkbox;

--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -32,4 +32,9 @@ Header.defaultProps = {
   Description: '',
 };
 
+Header.propDescriptions = {
+  Description: 'Either a string or component',
+  icon: 'String: One of any of the valid icon names',
+};
+
 export default Header;

--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -27,15 +27,18 @@ const Icon = props => (
   <span className={getClassName(props)}>{props.children}</span>
 );
 
+const colors = [ '', 'navy', 'teal', 'white', 'gray' ];
+const sizes = [ 'xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge' ];
+
 Icon.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   circle: PropTypes.bool,
-  color: PropTypes.oneOf([ '', 'navy', 'teal', 'white', 'gray' ]),
+  color: PropTypes.oneOf(colors),
   name: PropTypes.oneOf(iconList).isRequired,
   left: PropTypes.bool,
   right: PropTypes.bool,
-  size: PropTypes.oneOf([ 'xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge' ]),
+  size: PropTypes.oneOf(sizes),
 };
 
 Icon.defaultProps = {
@@ -46,6 +49,12 @@ Icon.defaultProps = {
   left: false,
   right: false,
   size: 'xsmall',
+};
+
+Icon.propDescriptions = {
+  color: `One of: ["${colors.join('", "')}"]`,
+  name: 'String: One of any of the valid icon names',
+  size: `One of: ["${sizes.join('", "')}"]`,
 };
 
 export default Icon;

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Radio from './Radio.jsx';
 import RadioButton from './RadioButton.jsx';
+import { noop } from '../util';
 
 function getClassName({ buttons, color, stacked }) {
   return classNames({
@@ -42,8 +43,6 @@ RadioGroup.propTypes = {
   selectedIndex: PropTypes.number,
   stacked: PropTypes.bool,
 };
-
-const noop = () => {};
 
 RadioGroup.defaultProps = {
   buttons: false,

--- a/components/RadioGroup/RadioGroup.jsx
+++ b/components/RadioGroup/RadioGroup.jsx
@@ -27,6 +27,8 @@ const RadioGroup = ({ buttons, color, items, onCheck, selectedIndex, stacked }) 
   </div>
 );
 
+const colors = [ 'teal', 'gray' ];
+
 const radioItemPropType = PropTypes.shape({
   label: PropTypes.string.isRequired,
   uniqueId: PropTypes.string.isRequired,
@@ -34,19 +36,25 @@ const radioItemPropType = PropTypes.shape({
 
 RadioGroup.propTypes = {
   buttons: PropTypes.bool,
-  color: PropTypes.oneOf([ 'teal', 'gray' ]),
+  color: PropTypes.oneOf(colors),
   items: PropTypes.arrayOf(radioItemPropType).isRequired,
   onCheck: PropTypes.func,
   selectedIndex: PropTypes.number,
   stacked: PropTypes.bool,
 };
 
+const noop = () => {};
+
 RadioGroup.defaultProps = {
   buttons: false,
   color: 'teal',
-  onCheck: () => {},
+  onCheck: noop,
   selectedIndex: -1,
   stacked: false,
+};
+
+RadioGroup.propDescriptions = {
+  color: `One of: ["${colors.join('", "')}"]`,
 };
 
 export default RadioGroup;

--- a/components/Select/SelectHOC.jsx
+++ b/components/Select/SelectHOC.jsx
@@ -62,10 +62,14 @@ export default function SelectHOC({ Dropdown, type }) {
     }
   }
 
+  const caretAligns = [ 'left', 'center', 'right' ];
+  const colors = [ 'gray', 'white', 'teal' ];
+  const dropdownPositions = [ 'above', 'below' ];
+
   Select.propTypes = {
-    caretAlign: PropTypes.oneOf([ 'left', 'center', 'right' ]),
-    color: PropTypes.oneOf([ 'gray', 'white', 'teal' ]),
-    dropdownPosition: PropTypes.oneOf([ 'above', 'below' ]),
+    caretAlign: PropTypes.oneOf(caretAligns),
+    color: PropTypes.oneOf(colors),
+    dropdownPosition: PropTypes.oneOf(dropdownPositions),
     inline: PropTypes.bool,
     isOpen: PropTypes.bool,
     maxLabelLength: PropTypes.number,
@@ -99,6 +103,14 @@ export default function SelectHOC({ Dropdown, type }) {
     Trigger: null,
     triggerLabel: '',
     triggerPlaceholder: 'Select an option',
+  };
+
+  Select.propDescriptions = {
+    caretAlign: `One of: ["${caretAligns.join('", "')}"]`,
+    color: `One of: ["${colors.join('", "')}"]`,
+    dropdownPosition: `One of: ["${dropdownPositions.join('", "')}"]`,
+    options: 'Array of: { label: String, uniqueId: String, description: String? }',
+    selectedOptions: 'Object of booleans',
   };
 
   return Select;

--- a/components/Text/Text.jsx
+++ b/components/Text/Text.jsx
@@ -23,6 +23,8 @@ const Text = props => (
   <span className={getClassName(props)}>{props.children}</span>
 );
 
+const colors = [ 'navy', 'gray', 'teal', 'white' ];
+
 Text.propTypes = {
   block: PropTypes.bool,
   children: PropTypes.node.isRequired,
@@ -32,7 +34,7 @@ Text.propTypes = {
   h4: PropTypes.bool,
   h5: PropTypes.bool,
   className: PropTypes.string,
-  color: PropTypes.oneOf([ 'navy', 'gray', 'teal', 'white' ]),
+  color: PropTypes.oneOf(colors),
 };
 
 Text.defaultProps = {
@@ -44,6 +46,11 @@ Text.defaultProps = {
   h5: false,
   className: '',
   color: 'navy',
+};
+
+Text.propDescriptions = {
+  block: 'Set to true to make block-level text. Otherwise defaults to inline.',
+  color: `One of: ["${colors.join('", "')}"]`,
 };
 
 export default Text;

--- a/components/util/index.js
+++ b/components/util/index.js
@@ -109,3 +109,5 @@ export function getAspectRatioHeight(aspectRatio, width) {
 export function immutableMerge(...args) {
   return Object.freeze(Object.assign({}, ...args));
 }
+
+export function noop() {}

--- a/demo/src/sections/Avatars.jsx
+++ b/demo/src/sections/Avatars.jsx
@@ -4,9 +4,10 @@ import { Avatar } from '../../../index.js';
 import {
   Block,
   DemoRow,
+  Details,
+  PropTypeTable,
   Subtitle,
   Title,
-  Details,
 } from '../ui';
 
 
@@ -62,10 +63,9 @@ const Avatars = ({ title }) => (
       <Details>
         Avatar sizes available: <code>xsmall</code>, <code>small</code>, <code>medium</code>, <code>large</code>, <code>xlarge</code>.
       </Details>
-
     </DemoRow>
     <DemoRow code={avatarCode}><AvatarDemo /></DemoRow>
-
+    <DemoRow><PropTypeTable component={Avatar} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Buttons.jsx
+++ b/demo/src/sections/Buttons.jsx
@@ -4,6 +4,7 @@ import { Button, Icon } from '../../../index.js';
 import {
   Block,
   DemoRow,
+  PropTypeTable,
   Title,
   Subtitle,
 } from '../ui';
@@ -152,6 +153,7 @@ const Buttons = ({ title }) => (
     <DemoRow code={buttonSizesCode}><ButtonSizes /></DemoRow>
     <DemoRow code={buttonTypefacesCode}><ButtonTypefaces /></DemoRow>
     <DemoRow code={buttonIconsCode}><ButtonIcons /></DemoRow>
+    <DemoRow><PropTypeTable component={Button} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Carousels.jsx
+++ b/demo/src/sections/Carousels.jsx
@@ -4,6 +4,7 @@ import { Carousel, Icon, Slide, util } from '../../../index.js';
 import {
   DemoRow,
   Details,
+  PropTypeTable,
   Subtitle,
   Title,
 } from '../ui';
@@ -248,6 +249,7 @@ const Carousels = ({ title }) => (
       </Details>
     </DemoRow>
     <DemoRow code={carouselCode}><CarouselDemo /></DemoRow>
+    <DemoRow><PropTypeTable component={Carousel} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Checkboxes.jsx
+++ b/demo/src/sections/Checkboxes.jsx
@@ -5,6 +5,7 @@ import {
   Block,
   DemoRow,
   Details,
+  PropTypeTable,
   Subtitle,
   Title,
 } from '../ui';
@@ -148,6 +149,7 @@ const Checkboxes = ({ title }) => (
     <DemoRow code={statelessCheckboxSizesCode}><StatelessCheckboxSizes /></DemoRow>
     <DemoRow code={statelessCheckboxTogglesCode}><StatelessCheckboxToggles /></DemoRow>
     <DemoRow code={statefulCheckboxCode}><StatefulCheckboxDemo /></DemoRow>
+    <DemoRow><PropTypeTable component={Checkbox} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Headers.jsx
+++ b/demo/src/sections/Headers.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Header } from '../../../index.js';
 import {
   DemoRow,
+  PropTypeTable,
   Subtitle,
   Title,
 } from '../ui';
@@ -63,6 +64,7 @@ const Headers = ({ title }) => (
     <DemoRow><Title>{title}</Title></DemoRow>
     <DemoRow code={defaultDemoCode}><DefaultDemo /></DemoRow>
     <DemoRow code={fullDemoCode}><FullDemo /></DemoRow>
+    <DemoRow><PropTypeTable component={Header} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Icons.jsx
+++ b/demo/src/sections/Icons.jsx
@@ -5,6 +5,7 @@ import iconNames from '../../../components/Icon/icon-list.js';
 import {
   Block,
   DemoRow,
+  PropTypeTable,
   Title,
   Subtitle,
 } from '../ui';
@@ -121,6 +122,7 @@ const Icons = ({ title }) => (
     <DemoRow code={iconCirclesCode}><IconCircles /></DemoRow>
     <DemoRow code={iconColorsCode}><IconColors /></DemoRow>
     <DemoRow code={iconListCode}><IconList /></DemoRow>
+    <DemoRow><PropTypeTable component={Icon} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Inputs.jsx
+++ b/demo/src/sections/Inputs.jsx
@@ -5,6 +5,7 @@ import {
   Block,
   DemoRow,
   Details,
+  PropTypeTable,
   Title,
   Subtitle,
 } from '../ui';
@@ -146,6 +147,7 @@ const Inputs = ({ title }) => (
     <DemoRow code={inputDemoCode}><InputDemo /></DemoRow>
     <DemoRow code={inputLabelCode}><InputLabel /></DemoRow>
     <DemoRow code={statefulInputCode}><StatefulInputDemo /></DemoRow>
+    <DemoRow><PropTypeTable component={Input} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Radios.jsx
+++ b/demo/src/sections/Radios.jsx
@@ -5,6 +5,7 @@ import {
   Block,
   DemoRow,
   Details,
+  PropTypeTable,
   Subtitle,
   Title,
 } from '../ui';
@@ -204,6 +205,7 @@ const Radios = ({ title }) => (
     <DemoRow code={stackedRadioCode}><StackedRadio /></DemoRow>
     <DemoRow code={radioButtonsCode}><RadioButtons /></DemoRow>
     <DemoRow code={statefulDemoCode}><StatefulDemo /></DemoRow>
+    <DemoRow><PropTypeTable component={RadioGroup} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Selects.jsx
+++ b/demo/src/sections/Selects.jsx
@@ -11,6 +11,7 @@ import {
   Block,
   Details,
   DemoRow,
+  PropTypeTable,
   Subtitle,
   Title,
 } from '../ui';
@@ -596,6 +597,7 @@ const Selects = ({ title }) => (
     <DemoRow code={statefulMultiSelectDemoCode}><StatefulMultiSelectDemo /></DemoRow>
     <DemoRow code={customTriggerDemoCode}><CustomTriggerDemo /></DemoRow>
     <DemoRow code={statefulMediaSelectDemoCode}><StatefulMediaSelectDemo /></DemoRow>
+    <DemoRow><PropTypeTable component={Select} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/Tags.jsx
+++ b/demo/src/sections/Tags.jsx
@@ -4,6 +4,7 @@ import { Tag } from '../../../index.js';
 import {
   Block,
   DemoRow,
+  PropTypeTable,
   Subtitle,
   Title,
 } from '../ui';
@@ -68,6 +69,7 @@ const Tags = ({ title }) => (
     <DemoRow code={tagsDemoCode}><TagsDemo /></DemoRow>
     <DemoRow code={truncatedDemoCode}><TruncatedDemo /></DemoRow>
     <DemoRow code={processingDemoCode}><ProcessingDemo /></DemoRow>
+    <DemoRow><PropTypeTable component={Tag} /></DemoRow>
   </div>
 );
 

--- a/demo/src/sections/TextDemo.jsx
+++ b/demo/src/sections/TextDemo.jsx
@@ -4,6 +4,7 @@ import { Text } from '../../../index.js';
 import {
   Block,
   DemoRow,
+  PropTypeTable,
   Subtitle,
   Title,
 } from '../ui';
@@ -63,6 +64,7 @@ const TextDemo = ({ title }) => (
     <DemoRow><Title>{title}</Title></DemoRow>
     <DemoRow code={textHeadingCode}><TextHeadings /></DemoRow>
     <DemoRow code={textColorsCode}><TextColors /></DemoRow>
+    <DemoRow><PropTypeTable component={Text} /></DemoRow>
   </div>
 );
 

--- a/demo/src/ui/PropTypeTable.jsx
+++ b/demo/src/ui/PropTypeTable.jsx
@@ -14,6 +14,7 @@ function lookupType(propType) {
 function stringify(prop) {
   if (typeof prop === 'string') return `"${prop}"`;
   if (typeof prop === 'function') return prop.name || '[Function]';
+  if (String(prop) === '[object Object]') return JSON.stringify(prop);
   return String(prop);
 }
 

--- a/demo/src/ui/PropTypeTable.jsx
+++ b/demo/src/ui/PropTypeTable.jsx
@@ -5,9 +5,8 @@ import Subtitle from './Subtitle.jsx';
 const propTypeList = Object.keys(PropTypes);
 
 function lookupType(propType) {
-  if (propType === PropTypes.node || propType === PropTypes.node.isRequired) return 'node';
   return propTypeList.reduce((current, next) => {
-    return propType === PropTypes[next] ? next : current;
+    return (propType === PropTypes[next] || propType === PropTypes[next].isRequired) ? next : current;
   }, 'other');
 }
 

--- a/demo/src/ui/PropTypeTable.jsx
+++ b/demo/src/ui/PropTypeTable.jsx
@@ -1,0 +1,71 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Subtitle from './Subtitle.jsx';
+
+const propTypeList = Object.keys(PropTypes);
+
+function lookupType(propType) {
+  if (propType === PropTypes.node || propType === PropTypes.node.isRequired) return 'node';
+  return propTypeList.reduce((current, next) => {
+    return propType === PropTypes[next] ? next : current;
+  }, 'other');
+}
+
+function stringify(prop) {
+  if (typeof prop === 'string') return `"${prop}"`;
+  if (typeof prop === 'function') return prop.name || '[Function]';
+  return String(prop);
+}
+
+class PropTypeTable extends PureComponent {
+  constructor(props) {
+    super(props);
+    const componentPropTypes = props.component.propTypes || {};
+    const componentDefaultProps = props.component.defaultProps || {};
+    const componentPropDescriptions = props.component.propDescriptions || {};
+    this.propList = Object.keys(componentPropTypes).map(prop => ({
+      prop,
+      type: lookupType(componentPropTypes[prop]),
+      defaultValue: stringify(componentDefaultProps[prop]),
+      description: componentPropDescriptions[prop],
+      isRequired: componentPropTypes[prop].isRequired === undefined,
+    }));
+  }
+  render() {
+    return (
+      <div>
+        <Subtitle>PropTypes</Subtitle>
+        <table className='table table--ticks table--striped margin-bottom-large'>
+          <thead>
+            <tr>
+              <th className='small-2'>Prop</th>
+              <th className='small-2'>Type</th>
+              <th className='small-2'>Required</th>
+              <th className='small-3'>Default value</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              this.propList.map(({ prop, type, defaultValue, description, isRequired }) => (
+                <tr key={prop}>
+                  <td><strong>{prop}</strong></td>
+                  <td>{type}</td>
+                  <td>{isRequired ? 'yes' : 'no' }</td>
+                  <td><code>{defaultValue}</code></td>
+                  <td>{description}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+PropTypeTable.propTypes = {
+  component: PropTypes.func.isRequired,
+};
+
+export default PropTypeTable;

--- a/demo/src/ui/index.js
+++ b/demo/src/ui/index.js
@@ -3,5 +3,6 @@ export { default as DemoRow } from './DemoRow.jsx';
 export { default as Details } from './Details.jsx';
 export { default as Hr } from './Hr.jsx';
 export { default as Nav } from './Nav.jsx';
+export { default as PropTypeTable } from './PropTypeTable.jsx';
 export { default as Subtitle } from './Subtitle.jsx';
 export { default as Title } from './Title.jsx';


### PR DESCRIPTION
## Overview
This PR improves the documentation within the demo site by displaying information about each component's props within a table.

This is great for documentation because we do not have to manually keep it in sync with the component. When the component's `propTypes` and `defaultProps` update, so will the `<PropTypeTable />`, automatically.

## Implementation details
It's only capable of detecting simple prop types, like `PropTypes.string`, not the kind that are returned by a function, like `PropTypes.arrayOf(PropTypes.string)`. Still, it is very helpful for the majority of cases, even just to see which props are available and required.

In addition, I've added a non-standard `propDescriptions` static property that can be used to write documentation for each prop _in the context of the component itself_. These descriptions are displayed in the table, in addition to whether or not the prop is required.

## Screenshot
<img width="1620" alt="screen shot 2017-08-10 at 5 28 38 pm" src="https://user-images.githubusercontent.com/2024396/29193570-e9901aac-7df3-11e7-85fb-bb1e0c0a389c.png">

## Questions
1. What do you think of `propDescriptions`? Is it a bad idea to have something non-standard attached to a component?
2. Is there any way to detect more prop types, like `arrayOf()`, `oneOf()`, etc.? So far, [the only implementation](https://github.com/storybooks/storybook/tree/master/addons/info) of such a table that I have seen include that information relied on a babel plugin to inject debug information into the components themselves. I would like to avoid that.