### PR TITLE
Add Slide Change Events to the Carousel

### DIFF
--- a/components/Carousel/Carousel.jsx
+++ b/components/Carousel/Carousel.jsx
@@ -193,7 +193,7 @@ Carousel.defaultProps = {
   animationDuration: 600, // ms
   aspectRatio: '16:6',
   maxHeight: 640, // px
-  minHeight: 368, //px
+  minHeight: 368, // px
   onSlideChange: () => {},
 };
 

--- a/components/Carousel/Carousel.jsx
+++ b/components/Carousel/Carousel.jsx
@@ -106,6 +106,8 @@ class Carousel extends Component {
         topSlideIndex: this.state.bgSlideIndex, // === i
       });
     }, this.props.animationDuration);
+
+    this.props.onSlideChange({ slideIndex: i, direction });
   }
 
   next() {
@@ -180,6 +182,7 @@ Carousel.propTypes = {
   aspectRatio: aspectRatioPropType,
   maxHeight: PropTypes.number,
   minHeight: PropTypes.number,
+  onSlideChange: PropTypes.func,
   slides: PropTypes.arrayOf(PropTypes.shape({
     Slide: PropTypes.func.isRequired,
     id: PropTypes.string.isRequired,
@@ -191,6 +194,7 @@ Carousel.defaultProps = {
   aspectRatio: '16:6',
   maxHeight: 640, // px
   minHeight: 368, //px
+  onSlideChange: () => {},
 };
 
 export default Carousel;

--- a/components/Carousel/Carousel.test.jsx
+++ b/components/Carousel/Carousel.test.jsx
@@ -95,4 +95,24 @@ describe('Carousel', () => {
     expect(wrapper.find('.carousel-arrow--left').length).to.equal(0);
     expect(wrapper.find('.carousel-arrow--right').length).to.equal(0);
   });
+
+  it('Calls `onSlideChange` when the slide changes', async () => {
+    let count = 0;
+    const onSlideChange = () => count++;
+    const ANIMATION_DURATION = 5;
+    const wrapper = shallow(<Carousel slides={slides} animationDuration={ANIMATION_DURATION} onSlideChange={onSlideChange} />);
+    const prevArrow = wrapper.find('.carousel-arrow--left');
+    const nextArrow = wrapper.find('.carousel-arrow--right');
+    const coin = wrapper.find('.coin').at(1);
+    expect(count).to.equal(0);
+    prevArrow.simulate('click');
+    expect(count).to.equal(1);
+    await wait(ANIMATION_DURATION);
+    nextArrow.simulate('click');
+    expect(count).to.equal(2);
+    await wait(ANIMATION_DURATION);
+    coin.simulate('click');
+    expect(count).to.equal(3);
+    await wait(ANIMATION_DURATION);
+  });
 });

--- a/components/Slide/Slide.jsx
+++ b/components/Slide/Slide.jsx
@@ -1,9 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Icon from '../Icon';
-import { If, getAspectRatioHeight, truncate } from '../util';
-
-const MAX_TITLE_LENGTH = 50; // characters
+import { getAspectRatioHeight } from '../util';
 
 class Slide extends Component {
   constructor() {
@@ -25,32 +22,18 @@ class Slide extends Component {
 
   render() {
     const { animationDuration, enter, enterDirection, exitDirection, isMobile, zIndex } = this.props.dynamicProps;
-    const { buttonClass, title, subtitle, description, img, mobileImg, links, isWide } = this.props;
+    const { children, img, mobileImg, isWide } = this.props;
     const display = zIndex === '-1' ? 'none' : 'block';
     return (
       <div className={`slide ${exitDirection} ${enter ? `ENTER_${enterDirection}` : ''}`} style={{ animationDuration: `${animationDuration}ms`, display, zIndex }}>
         <div className={isMobile ? 'slide-bg slide-bg--mobile' : 'slide-bg' }>
           <div className={isWide ? 'slide-layout-wide' : 'slide-layout-container'}>
-            <img className='slide-bg-img' src={isMobile ? mobileImg : img} alt={title} style={{ height: `${this.getImgHeight()}px` }} />
+            <img className='slide-bg-img' src={isMobile ? mobileImg : img} alt='Slide image' style={{ height: `${this.getImgHeight()}px` }} />
           </div>
         </div>
         <div className='slide-layout-container'>
           <div className={isMobile ? 'slide-content slide-content--mobile' : 'slide-content'}>
-            <div className='slide-title'>{truncate(title, MAX_TITLE_LENGTH)}</div>
-            <div className='slide-subtitle'>{subtitle}</div>
-            <div className='slide-description'>{description}</div>
-            <div className='slide-buttons'>
-              <a className={`btn btn-gray btn-site-primary slide-button ${buttonClass}`} href={links.item}>
-                <Icon name='play' color='white' size='xxsmall' />
-                <span className='slide-button-text'>Watch now</span>
-              </a>
-              <If condition={Boolean(links.trailer)} inline>
-                <a className='btn btn-transparent slide-button slide-button--alt' href={links.trailer}>
-                  <Icon name='play' color='white' size='xxsmall' />
-                  <span className='slide-button-text'>Trailer</span>
-                </a>
-              </If>
-            </div>
+            { children }
           </div>
         </div>
       </div>
@@ -69,23 +52,14 @@ Slide.propTypes = {
     width: PropTypes.number.isRequired,
     zIndex: PropTypes.string.isRequired,
   }).isRequired,
-  buttonClass: PropTypes.string,
-  description: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   img: PropTypes.string.isRequired,
-  links: PropTypes.shape({
-    trailer: PropTypes.string,
-    item: PropTypes.string.isRequired,
-  }).isRequired,
   mobileImg: PropTypes.string.isRequired,
   isWide: PropTypes.bool,
-  title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string,
 };
 
 Slide.defaultProps = {
-  buttonClass: 'slide-button--default',
   isWide: false,
-  subtitle: '',
 };
 
 export default Slide;

--- a/demo/src/sections/Carousels.jsx
+++ b/demo/src/sections/Carousels.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Carousel, Slide } from '../../../index.js';
+import { Carousel, Icon, Slide, util } from '../../../index.js';
 import {
   DemoRow,
   Details,
@@ -12,23 +12,48 @@ import {
 // Carousel demo
 // -----------------------------------------
 
+const MAX_TITLE_LENGTH = 50; // characters
 const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua';
+
+const BrowsePageSlide = ({ title, subtitle, description, buttonClass, links }) => (
+  <div>
+    <div className='slide-title'>{util.truncate(title, MAX_TITLE_LENGTH)}</div>
+    <div className='slide-subtitle'>{subtitle}</div>
+    <div className='slide-description'>{description}</div>
+    <div className='slide-buttons'>
+      <a className={`btn btn-gray btn-site-primary slide-button ${buttonClass}`} href={links.item}>
+        <Icon name='play' color='white' size='xxsmall' />
+        <span className='slide-button-text'>Watch now</span>
+      </a>
+      <util.If condition={Boolean(links.trailer)} inline>
+        <a className='btn btn-transparent slide-button slide-button--alt' href={links.trailer}>
+          <Icon name='play' color='white' size='xxsmall' />
+          <span className='slide-button-text'>Trailer</span>
+        </a>
+      </util.If>
+    </div>
+  </div>
+);
 
 const Slide1 = {
   Slide: props => (
     <Slide
       dynamicProps={props}
-      title='Slide 1 title'
-      subtitle='3 Seasons'
-      description={lorem}
       img='/images/16-6-A.png'
       mobileImg='/images/16-6-A-mob.png'
       isWide={true}
-      links={{
-        item: '#',
-        trailer: '#',
-      }}
-    />
+    >
+      <BrowsePageSlide
+        title='Slide 1 title'
+        subtitle='3 Seasons'
+        description={lorem}
+        buttonClass=''
+        links={{
+          item: '#',
+          trailer: '#',
+        }}
+      />
+    </Slide>
   ),
   id: 's1',
 };
@@ -37,17 +62,21 @@ const Slide2 = {
   Slide: props => (
     <Slide
       dynamicProps={props}
-      title='Slide 2 title is a very long title with many words'
-      subtitle='3 Seasons'
-      description={lorem}
       img='/images/16-9-B.png'
       mobileImg='/images/16-9-B-mob.png'
-      isWide={false}
-      links={{
-        item: '#',
-        trailer: '#',
-      }}
-    />
+      isWide={true}
+    >
+      <BrowsePageSlide
+        title='Slide 2 title is a very long title with many words'
+        subtitle='3 Seasons'
+        description={lorem}
+        buttonClass=''
+        links={{
+          item: '#',
+          trailer: '#',
+        }}
+      />
+    </Slide>
   ),
   id: 's2',
 };
@@ -56,18 +85,21 @@ const Slide3 = {
   Slide: props => (
     <Slide
       dynamicProps={props}
-      buttonClass='btn-teal'
-      title='Slide 3 has a custom button class'
-      subtitle='3 Seasons'
-      description={lorem}
       img='/images/16-9-A.png'
       mobileImg='/images/16-9-A-mob.png'
       isWide={false}
-      links={{
-        item: '#',
-        trailer: '#',
-      }}
-    />
+    >
+      <BrowsePageSlide
+        title='Slide 3 has a custom button class'
+        subtitle='3 Seasons'
+        description={lorem}
+        buttonClass='btn-teal'
+        links={{
+          item: '#',
+          trailer: '#',
+        }}
+      />
+    </Slide>
   ),
   id: 's3',
 };
@@ -76,14 +108,20 @@ const Slide4 = {
   Slide: props => (
     <Slide
       dynamicProps={props}
-      title='Slide 4 has no trailer'
-      subtitle='3 Seasons'
-      description={lorem}
       img='/images/16-9-B.png'
       mobileImg='/images/16-9-B-mob.png'
       isWide={false}
-      links={{ item: '#' }}
-    />
+    >
+      <BrowsePageSlide
+        title='Slide 4'
+        subtitle='3 Seasons'
+        description={lorem}
+        links={{
+          item: '#',
+          trailer: '#',
+        }}
+      />
+    </Slide>
   ),
   id: 's4',
 };
@@ -92,14 +130,21 @@ const Slide5 = {
   Slide: props => (
     <Slide
       dynamicProps={props}
-      title='Slide 5 has no trailer and is 16:6 with a very long title containing many words. 100 characters long'
-      subtitle='3 Seasons'
-      description={lorem}
       img='/images/16-6-B.png'
       mobileImg='/images/16-6-B-mob.png'
       isWide={true}
-      links={{ item: '#' }}
-    />
+    >
+      <BrowsePageSlide
+        title='Slide 5 has no trailer and is 16:6 with a very long title containing many words. 100 characters long'
+        subtitle='3 Seasons'
+        description={lorem}
+        buttonClass='btn-teal'
+        links={{
+          item: '#',
+          trailer: '#',
+        }}
+      />
+    </Slide>
   ),
   id: 's5',
 };
@@ -108,14 +153,17 @@ const loadTestSlides = Array(50).fill(true).map((x, i) => ({
   Slide: props => (
     <Slide
       dynamicProps={props}
-      title={`Slide ${i}`}
-      subtitle='(Load test slide)'
-      description={lorem}
       img={`http://lorempizza.com/1600/600/${i}`}
       mobileImg={`http://lorempizza.com/1600/900/${i}`}
       isWide={true}
-      links={{ item: '#' }}
-    />
+    >
+      <BrowsePageSlide
+        title={`Slide ${i}`}
+        subtitle='(Load-test slide)'
+        description={lorem}
+        links={{ item: '#' }}
+      />
+    </Slide>
   ),
   id: `slide${i}`,
 }));
@@ -165,11 +213,11 @@ const Carousels = ({ title }) => (
     <DemoRow>
       <Title>{title}</Title>
       <Details>
-        Carousels are composed of two components. There is the base <code>Carousel</code>
+        Carousels are composed of three components. There is the base <code>Carousel</code>
         component which handles the navigation ui and aspect ratio sizing. Then there is
-        the <code>Slide</code> component which is a specific implementation of a slide that
-        could be passed to the carousel. The carousel passes many props to the slide component,
-        such as its height and animation duration.
+        the <code>Slide</code> which handles the background images animations between
+        slide changes. Finally, there are the children passed into the <code>Slide</code>
+        component, which can be any arbitrary components.
       </Details>
       <Details>
         The only required prop that a Carousel component requires is an array of objects of the

--- a/demo/src/sections/Carousels.jsx
+++ b/demo/src/sections/Carousels.jsx
@@ -238,6 +238,19 @@ const Carousels = ({ title }) => (
         prop which is a string formatted like <code>16:9</code>. If not provided, the default
         is <code>16:6</code>.
       </Details>
+      <Details>
+        The <code>Carousel</code> accepts an <code>onSlideChange</code> prop that is a function
+        which gets called whenever the slide changes. The function will be passed an object of
+        the following form:
+        <pre className='code'>
+          {
+  `{
+  direction: String,
+  slideIndex: Number,
+}`
+          }
+        </pre>
+      </Details>
     </DemoRow>
     <DemoRow code={carouselCode}><CarouselDemo /></DemoRow>
   </div>


### PR DESCRIPTION
## Overview

This PR makes it possible to implement GA tracking on the carousel by exposing a handler that reacts to slide change events.

Whenever the slide changes, the `onSlideChange` function (prop) is called.

---

This PR also makes it possible to implement GA tracking within the slides themselves by separating the slide contents from the wrapper which handles their animations.