### PR TITLE
Make layout wider on small screens so that the propTypeTable has room

### DIFF
--- a/demo/src/ui/DemoRow.jsx
+++ b/demo/src/ui/DemoRow.jsx
@@ -25,11 +25,11 @@ class DemoRow extends Component {
   render() {
     return (
       <div className='row'>
-        <div className='column medium-16 large-10 xlarge-11 padding-reset'>
+        <div className='column small-16 medium-16 large-16 xlarge-10 padding-reset'>
           <div className='guide-bar' style={{ minHeight: `${this.state.codeHeight}px` }}>{this.props.children}</div>
         </div>
         <If condition={Boolean(this.props.code)}>
-          <div className='column medium-0 large-6 xlarge-5 padding-reset' ref={this.setHeightOnce}>
+          <div className='column small-0 medium-0 large-0 xlarge-6 padding-reset' ref={this.setHeightOnce}>
             <div className='code-bar'>
               <pre className='padding-medium'>
                 <code dangerouslySetInnerHTML={this.markupCode()} />


### PR DESCRIPTION
## Overview
This PR gives the `<PropTypeTable />` a bit more room on smaller (tablet-sized) screens by stacking the layout.

## Screenshots

##### Before
![screen shot 2017-08-15 at 1 56 52 pm](https://user-images.githubusercontent.com/2024396/29328802-bfcddb92-81c1-11e7-8830-48b30e3f3e05.png)

##### After
![screen shot 2017-08-15 at 1 56 20 pm](https://user-images.githubusercontent.com/2024396/29328809-c4561828-81c1-11e7-9345-9c7b2da1cc6a.png)
