### PR TITLE
Featured carousel blue button fix

### DIFF
--- a/demo/public/css/carousel.css
+++ b/demo/public/css/carousel.css
@@ -107,5 +107,5 @@
 .coin[disabled]:active,
 .coin[disabled]:hover,
 .coin[disabled]:focus, {
-  background-color: #fff;
+  background-color: #fff !important;
 }

--- a/demo/public/css/carousel.css
+++ b/demo/public/css/carousel.css
@@ -1,5 +1,5 @@
 .carousel {
-  background: #000;
+  background-color: #000;
   color: #fff;
   overflow: hidden;
   position: relative;
@@ -12,7 +12,7 @@
 }
 
 .carousel-arrow {
-  background: transparent;
+  background-color: transparent;
   border: 0;
   border-radius: 0;
   height: 100%;
@@ -32,7 +32,7 @@
 .carousel-arrow[disabled]:active,
 .carousel-arrow[disabled]:hover,
 .carousel-arrow[disabled]:focus {
-  background: transparent;
+  background-color: transparent;
 }
 
 .carousel:hover .carousel-arrow {
@@ -82,7 +82,7 @@
 }
 
 .coin {
-  background: #fff;
+  background-color: #fff;
   border: 0;
   borderRadius: 4px; /* 50% of height */
   box-shadow: 0 1px 5px #000;
@@ -107,5 +107,5 @@
 .coin[disabled]:active,
 .coin[disabled]:hover,
 .coin[disabled]:focus, {
-  background: #fff;
+  background-color: #fff;
 }

--- a/dist/carousel.css
+++ b/dist/carousel.css
@@ -1,10 +1,10 @@
 /*
   Quartz-react version: 0.1.3
-  Current file hash: 064240763173612ae21da9cf52848651
+  Current file hash: 115b6a0d9ffda7da6978183974bd0aef
 */
 
 .carousel {
-  background: #000;
+  background-color: #000;
   color: #fff;
   overflow: hidden;
   position: relative;
@@ -17,7 +17,7 @@
 }
 
 .carousel-arrow {
-  background: transparent;
+  background-color: transparent;
   border: 0;
   border-radius: 0;
   height: 100%;
@@ -37,7 +37,7 @@
 .carousel-arrow[disabled]:active,
 .carousel-arrow[disabled]:hover,
 .carousel-arrow[disabled]:focus {
-  background: transparent;
+  background-color: transparent;
 }
 
 .carousel:hover .carousel-arrow {
@@ -87,7 +87,7 @@
 }
 
 .coin {
-  background: #fff;
+  background-color: #fff;
   border: 0;
   borderRadius: 4px; /* 50% of height */
   box-shadow: 0 1px 5px #000;
@@ -112,5 +112,5 @@
 .coin[disabled]:active,
 .coin[disabled]:hover,
 .coin[disabled]:focus, {
-  background: #fff;
+  background-color: #fff;
 }

--- a/dist/carousel.css
+++ b/dist/carousel.css
@@ -1,6 +1,6 @@
 /*
   Quartz-react version: 0.1.3
-  Current file hash: 115b6a0d9ffda7da6978183974bd0aef
+  Current file hash: f68f75f5319db5565fb7f6a68a713f9a
 */
 
 .carousel {
@@ -112,5 +112,5 @@
 .coin[disabled]:active,
 .coin[disabled]:hover,
 .coin[disabled]:focus, {
-  background-color: #fff;
+  background-color: #fff !important;
 }

--- a/dist/carousel.css
+++ b/dist/carousel.css
@@ -112,5 +112,5 @@
 .coin[disabled]:active,
 .coin[disabled]:hover,
 .coin[disabled]:focus, {
-  background: #fff;
+  background: #fff !important;
 }

--- a/dist/carousel.css
+++ b/dist/carousel.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: 064240763173612ae21da9cf52848651
 */
 
@@ -112,5 +112,5 @@
 .coin[disabled]:active,
 .coin[disabled]:hover,
 .coin[disabled]:focus, {
-  background: #fff !important;
+  background: #fff;
 }

--- a/dist/components.css
+++ b/dist/components.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: c2fb89079b659aa7fe31670bc0a4c160
 */
 

--- a/dist/demo.css
+++ b/dist/demo.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: 1b9a1a73053e8c1ff0f9fe7349e22367
 */
 

--- a/dist/pagination.css
+++ b/dist/pagination.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: 0616794a7f4ff49554971aeda2eb5f80
 */
 

--- a/dist/quartz-icons.css
+++ b/dist/quartz-icons.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: 4b8934d93662a884d7251015106c49a3
 */
 

--- a/dist/quartz.css
+++ b/dist/quartz.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: a1736d53e5e24089e9eabd8e05d4555a
 */
 

--- a/dist/sidebar.css
+++ b/dist/sidebar.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: 84597099e5e0f8f7fecadfd205ab51f2
 */
 

--- a/dist/slide.css
+++ b/dist/slide.css
@@ -1,5 +1,5 @@
 /*
-  Quartz-react version: 0.1.2
+  Quartz-react version: 0.1.3
   Current file hash: 23e145e1c6d946775b1f196d0c6ba97e
 */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vhx/quartz-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "React Components for VHX Quartz",
   "main": "dist/quartz-react.js",
   "scripts": {


### PR DESCRIPTION
## Overview

When using the featured content carousel in production, the carousel `.coin` buttons inherit a blue color from some other css.

This PR resolves that issue, in an inelegant way, by increasing the precedence using `!important`. 

Screenshot attached with the conflicting css that appears to be applied to all elements of type `button`.

![screen shot 2017-08-16 at 3 14 47 pm](https://user-images.githubusercontent.com/2024396/29381199-6a936dce-8296-11e7-9a9b-447df09a5071.png)
